### PR TITLE
Windows support + never host the status row on another plugin's pane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,10 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "space-usage"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "libc",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "space-usage"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "libc",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -113,12 +113,13 @@ dependencies = [
 
 [[package]]
 name = "space-usage"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "libc",
  "serde",
  "serde_json",
  "signal-hook",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -146,12 +147,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "space-usage"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2021"
 description = "CPU and RAM usage per herdr space, grouped under the branch name."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "space-usage"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 description = "CPU and RAM usage per herdr space, grouped under the branch name."
 license = "MIT"
@@ -11,8 +11,20 @@ license = "MIT"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 signal-hook = "0.3"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_ProcessStatus",
+    "Win32_System_SystemInformation",
+    "Win32_System_Threading",
+    "Win32_System_Console",
+] }
 
 [profile.release]
 opt-level = "z"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "space-usage"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 description = "CPU and RAM usage per herdr space, grouped under the branch name."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ signal-hook = "0.3"
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
+    "Win32_Storage_FileSystem",           # SECURITY_IDENTIFICATION (pipe SQOS)
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_ProcessStatus",
     "Win32_System_SystemInformation",

--- a/README.md
+++ b/README.md
@@ -158,6 +158,30 @@ would blank the branch out. For the same reason the branch uses `cwd` and not
 `foreground_cwd` — the latter is the field that became non-blocking in 0.8.0
 (#1838, #2206) and transiently reports `/`.
 
+### Living alongside other plugins
+
+In **agents-panel** mode the usage row needs a pane to live on, and it will
+never take one that belongs to another plugin. A pane with no agent but with
+metadata tokens that aren't ours (herdr-sidebar's explorer/git heartbeats, for
+example) is treated as owned and skipped — otherwise the panel grows a second
+"agent" row and the usage text ends up pinned inside someone else's pane.
+
+Two consequences worth knowing:
+
+- If **every** agent-less pane in a space belongs to another plugin, that space
+  gets no row of its own; its usage is shown on one of its agent rows instead.
+  Open any plain shell pane in the space to get the dedicated row back.
+- Usage numbers are never affected. Measurement walks every pane in the space
+  regardless of who owns it, so plugin panes still count toward its CPU and RAM.
+
+This is a heuristic, and it has to be: herdr reports a pane's tokens as one flat
+map merged across all plugins, with no record of who set what. A plugin that
+puts tokens on ordinary shell panes will shrink the pool of panes this one can
+use, and a plugin that names a token `usage` will look like us.
+
+**sidebar** mode is unaffected — it reports at the workspace level and never
+claims a pane at all.
+
 ## Development
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ a glance which space is eating your machine.
 - All-space totals in your terminal's window title: `spaces · cpu 39% · ram 8%`
 - A live dashboard pane and one-shot report/JSON actions
 - A small static Rust binary (~2–5 MB resident) that talks to herdr over its
-  unix socket — no per-sample subprocess spawns, no Node runtime
+  unix socket (a named pipe on Windows) — no per-sample subprocess spawns, no
+  Node runtime
+- Runs on **Linux and Windows** (herdr Windows beta)
 
 ## Install
 
@@ -30,10 +32,17 @@ a glance which space is eating your machine.
 herdr plugin install ezcorp-org/herdr-pc-ram-and-cpu-usage-overlay
 ```
 
-Requirements: Linux (reads `/proc`) and the **Rust toolchain** (`cargo`) on the
-box hosting the herdr server — herdr compiles the plugin at install time via
+Requirements: Linux or Windows, and the **Rust toolchain** (`cargo`) on the box
+hosting the herdr server — herdr compiles the plugin at install time via
 `cargo build --release`. Plugins run on the machine hosting the herdr server, so
 remote setups need these on the server box only. `node` is no longer required.
+
+On Windows the sampling uses the Win32 process APIs instead of `/proc`, and the
+herdr socket is reached through its named pipe; both are handled automatically.
+If your Rust toolchain targets `x86_64-pc-windows-gnu`, the MinGW binutils
+(`dlltool`, `as`) must be on `PATH` for the build (rustup's self-contained set
+is not sufficient); the MSVC target needs the Visual C++ build tools plus the
+Windows SDK, as usual.
 
 ## Usage
 
@@ -121,13 +130,20 @@ which reads the same two keys. Restart the updater to pick up a change.
 
 ## How it works
 
-The binary opens one persistent connection to the herdr unix socket and speaks
-its newline-delimited JSON-RPC. Per refresh: `session.snapshot` returns every
-workspace and pane in a single call → `pane.process_info` yields each pane's
-`shell_pid` → the process walks that PID's `/proc` subtree, summing CPU
-(utime+stime jiffie deltas over a sample window) and RSS. Branch comes from the
-pane cwd's git checkout, and worktree families from `worktree.list`. Clock ticks
-(`_SC_CLK_TCK`) and page size (`_SC_PAGESIZE`) are probed via `sysconf`.
+The binary opens one persistent connection to the herdr unix socket (on Windows
+the same JSON-RPC rides the named pipe `\\.\pipe\<HERDR_SOCKET_PATH>`) and
+speaks its newline-delimited JSON-RPC. Per refresh: `session.snapshot` returns
+every workspace and pane in a single call → `pane.process_info` yields each
+pane's `shell_pid` → the process walks that PID's process subtree, summing CPU
+and RSS over a sample window. Branch comes from the pane cwd's git checkout, and
+worktree families from `worktree.list`.
+
+Per platform: Linux reads `/proc/<pid>/stat` (utime+stime jiffie deltas,
+`sysconf` clock ticks/page size) and `statm` RSS; Windows snapshots the process
+table via Toolhelp32, reads cumulative CPU from `GetProcessTimes` (100 ns
+FILETIME ticks), working sets via `K32GetProcessMemoryInfo`, and the machine
+total via `GlobalMemoryStatusEx`. Processes the plugin cannot open still keep
+their pid→ppid edge so subtree topology stays correct.
 
 Workspaces and panes deliberately come from the **one** `session.snapshot` call
 rather than `workspace.list` plus a `pane.list` per workspace: the two can be

--- a/README.md
+++ b/README.md
@@ -169,8 +169,10 @@ example) is treated as owned and skipped — otherwise the panel grows a second
 Two consequences worth knowing:
 
 - If **every** agent-less pane in a space belongs to another plugin, that space
-  gets no row of its own; its usage is shown on one of its agent rows instead.
-  Open any plain shell pane in the space to get the dedicated row back.
+  gets no row of its own; its usage is shown on one of its agent rows instead
+  (which is what `[ui.sidebar.agents]`'s `$usage` renders anyway). If it has no
+  agent panes either, the space shows nothing until one appears. Opening any
+  plain shell pane in the space restores the dedicated row.
 - Usage numbers are never affected. Measurement walks every pane in the space
   regardless of who owns it, so plugin panes still count toward its CPU and RAM.
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -13,7 +13,7 @@
 
 id = "ez-corp.space-usage"
 name = "PC RAM & CPU Usage Overlay"
-version = "1.4.0"
+version = "1.4.1"
 # Oldest herdr with every API this plugin calls: `session.snapshot`, the `tokens`
 # metadata API on `pane.report_metadata` / `workspace.report_metadata`, and
 # `pane.process_info` — all 0.7.5. Diffing the two bundled API schemas

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -13,7 +13,7 @@
 
 id = "ez-corp.space-usage"
 name = "PC RAM & CPU Usage Overlay"
-version = "1.3.0"
+version = "1.4.0"
 # Oldest herdr with every API this plugin calls: `session.snapshot`, the `tokens`
 # metadata API on `pane.report_metadata` / `workspace.report_metadata`, and
 # `pane.process_info` — all 0.7.5. Diffing the two bundled API schemas
@@ -21,7 +21,7 @@ version = "1.3.0"
 # used here, so this stays put; developed and tested against 0.8.0.
 min_herdr_version = "0.7.5"
 description = "CPU and RAM usage per space, grouped under the branch name."
-platforms = ["linux"]
+platforms = ["linux", "windows"]
 
 # Commands are argv arrays (no shell) and run with the plugin dir as cwd,
 # per https://herdr.dev/docs/plugins/#trust-and-security
@@ -31,7 +31,7 @@ platforms = ["linux"]
 # what every pane/action command below invokes (relative to the plugin root).
 [[build]]
 command = ["cargo", "build", "--release"]
-platforms = ["linux"]
+platforms = ["linux", "windows"]
 
 # Restart recovery. herdr runs startup hooks on both a fresh server start and a
 # live handoff (`herdr update --handoff`), so this fires whenever herdr comes
@@ -42,7 +42,7 @@ platforms = ["linux"]
 # the sidebar stays blank until someone re-invokes status-enable by hand.
 [[startup]]
 command = ["./target/release/space-usage", "--restore"]
-platforms = ["linux"]
+platforms = ["linux", "windows"]
 
 # Live, self-refreshing dashboard. Opened as a temporary zoomed overlay pane.
 [[panes]]

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -13,7 +13,7 @@
 
 id = "ez-corp.space-usage"
 name = "PC RAM & CPU Usage Overlay"
-version = "1.4.1"
+version = "1.5.0"
 # Oldest herdr with every API this plugin calls: `session.snapshot`, the `tokens`
 # metadata API on `pane.report_metadata` / `workspace.report_metadata`, and
 # `pane.process_info` — all 0.7.5. Diffing the two bundled API schemas

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -69,6 +69,18 @@ fn classify_panes(panes: &[&PaneInfo]) -> PaneRoles {
 /// the panel and pinned the usage text to the wrong pane. Our own fall-through
 /// `usage` token must NOT trip this, or a pane we reported once would stop
 /// being a spare pane on the next cycle.
+///
+/// A HEURISTIC, and deliberately so: herdr's `PaneInfo.tokens` is one flat
+/// `map<string,string>` merged across every reporting source, with no ownership
+/// field anywhere on the pane, so "someone else annotated this pane" is the
+/// strongest signal the API offers. Two known costs, both preferred to grabbing
+/// a pane that isn't ours:
+///
+/// - a plugin that badges PLAIN SHELL panes rather than opening its own shrinks
+///   the spare pool; if it badges every agent-less pane in a workspace, that
+///   space gets no dedicated row and its usage rides on an agent pane instead
+///   (see the fall-through in [`crate::daemon::push_statuses`]);
+/// - a plugin that names a token `usage` reads as a spare pane here.
 fn is_plugin_pane(pane: &PaneInfo) -> bool {
     pane.tokens
         .as_ref()
@@ -343,7 +355,7 @@ mod tests {
         let mut p = pane(pane_id, "w1", None, None);
         p.tokens = Some(
             keys.iter()
-                .map(|k| (k.to_string(), serde_json::Value::from("x")))
+                .map(|k| (k.to_string(), "x".to_string()))
                 .collect(),
         );
         p
@@ -437,6 +449,47 @@ mod tests {
         p.agent = Some("claude".to_string());
         let refs: Vec<&PaneInfo> = [&p].to_vec();
         assert_eq!(classify_panes(&refs).agent_panes, ["claude"]);
+    }
+
+    #[test]
+    fn classify_treats_an_empty_token_map_as_a_plain_pane() {
+        // herdr sends `tokens` as an empty object once every token on a pane has
+        // expired or been cleared. "Present but empty" is not ownership.
+        let panes = [pane_with_tokens("shell", &[])];
+        let refs: Vec<&PaneInfo> = panes.iter().collect();
+        assert_eq!(classify_panes(&refs).spare_panes, ["shell"]);
+    }
+
+    #[test]
+    fn classification_drops_only_plugin_panes() {
+        // The safety property behind the new arm: a pane may be left out of
+        // every bucket ONLY for being plugin-owned. Anything else silently
+        // vanishing would be a space losing its status host for no reason.
+        let mut agent = pane("claude", "w1", None, None);
+        agent.agent = Some("claude".to_string());
+        let mut pseudo = pane("ours", "w1", None, None);
+        pseudo.agent = Some(PSEUDO_AGENT.to_string());
+        let panes = [
+            agent,
+            pseudo,
+            pane("shell", "w1", None, None),
+            pane_with_tokens("mine-only", &[PSEUDO_AGENT]),
+            pane_with_tokens("theirs", &["herdr-sidebar-git"]),
+        ];
+        let refs: Vec<&PaneInfo> = panes.iter().collect();
+        let roles = classify_panes(&refs);
+
+        let mut bucketed: Vec<&str> = roles
+            .agent_panes
+            .iter()
+            .chain(&roles.spare_panes)
+            .chain(&roles.pseudo_panes)
+            .map(String::as_str)
+            .collect();
+        bucketed.sort_unstable();
+        // Everything is placed except the one pane another plugin owns.
+        assert_eq!(bucketed, ["claude", "mine-only", "ours", "shell"]);
+        assert_eq!(bucketed.len() + 1, panes.len());
     }
 
     /// Build a measured [`Space`] with just the aggregate-relevant fields set.

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -452,6 +452,27 @@ mod tests {
     }
 
     #[test]
+    fn classify_misreads_a_foreign_usage_token_as_ours() {
+        // KNOWN LIMITATION, pinned deliberately rather than left as prose.
+        //
+        // herdr merges every plugin's tokens into one flat map and does not say
+        // who wrote what, so `usage` from another plugin is indistinguishable
+        // from ours and its pane is offered as a spare — the pane-grab this
+        // guard otherwise prevents. Closing it means renaming our token, which
+        // silently blanks the sidebar of everyone whose herdr config says
+        // `$usage`; with the plugin already widely installed that trade is not
+        // worth a collision no plugin has yet caused. The real fix is upstream:
+        // expose on read the `source` that `pane.report_metadata` already
+        // requires on write.
+        //
+        // If this test ever fails, the rename happened — update the README's
+        // "Living alongside other plugins" section with it.
+        let panes = [pane_with_tokens("someone-elses", &[PSEUDO_AGENT])];
+        let refs: Vec<&PaneInfo> = panes.iter().collect();
+        assert_eq!(classify_panes(&refs).spare_panes, ["someone-elses"]);
+    }
+
+    #[test]
     fn classify_treats_an_empty_token_map_as_a_plain_pane() {
         // herdr sends `tokens` as an empty object once every token on a pane has
         // expired or been cleared. "Present but empty" is not ownership.

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -40,7 +40,10 @@ struct PaneRoles {
 /// The first pane with a non-empty cwd wins the branch lookup. `cwd` is optional
 /// in herdr's payload and can be briefly absent while a pane is still starting,
 /// so a later pane is allowed to supply it. Bucketing: our pseudo-agent first,
-/// then any other non-empty agent, else a plain shell pane.
+/// then any other non-empty agent, else a plain shell pane — EXCEPT panes owned
+/// by another plugin ([`is_plugin_pane`]), which are never status hosts. They
+/// still count toward the space's usage: measurement runs off `roots`, which
+/// covers every pane regardless of these buckets.
 fn classify_panes(panes: &[&PaneInfo]) -> PaneRoles {
     let mut roles = PaneRoles::default();
     for pane in panes {
@@ -52,10 +55,24 @@ fn classify_panes(panes: &[&PaneInfo]) -> PaneRoles {
         match pane.agent.as_deref() {
             Some(PSEUDO_AGENT) => roles.pseudo_panes.push(pane.pane_id.clone()),
             Some(agent) if !agent.is_empty() => roles.agent_panes.push(pane.pane_id.clone()),
+            _ if is_plugin_pane(pane) => {} // measured via roots, never a status host
             _ => roles.spare_panes.push(pane.pane_id.clone()),
         }
     }
     roles
+}
+
+/// Whether an agent-less pane belongs to another plugin: it carries metadata
+/// tokens other than our own `usage` token. Plugin panes (herdr-sidebar's
+/// explorer/git pane, llmtrim's dashboards, ..) stamp identity/heartbeat tokens
+/// on themselves; claiming our pseudo-agent there put a second "agent" row in
+/// the panel and pinned the usage text to the wrong pane. Our own fall-through
+/// `usage` token must NOT trip this, or a pane we reported once would stop
+/// being a spare pane on the next cycle.
+fn is_plugin_pane(pane: &PaneInfo) -> bool {
+    pane.tokens
+        .as_ref()
+        .is_some_and(|tokens| tokens.keys().any(|key| key != PSEUDO_AGENT))
 }
 
 /// Bucket a snapshot's flat pane list under each pane's `workspace_id`, keeping
@@ -317,7 +334,19 @@ mod tests {
             workspace_id: workspace_id.to_string(),
             cwd: cwd.map(str::to_string),
             agent: agent.map(str::to_string),
+            tokens: None,
         }
+    }
+
+    /// A [`PaneInfo`] carrying metadata tokens with the given keys.
+    fn pane_with_tokens(pane_id: &str, keys: &[&str]) -> PaneInfo {
+        let mut p = pane(pane_id, "w1", None, None);
+        p.tokens = Some(
+            keys.iter()
+                .map(|k| (k.to_string(), serde_json::Value::from("x")))
+                .collect(),
+        );
+        p
     }
 
     // ---- pane bucketing + classification ------------------------------------
@@ -371,6 +400,43 @@ mod tests {
     #[test]
     fn classify_of_no_panes_is_all_empty() {
         assert_eq!(classify_panes(&[]), PaneRoles::default());
+    }
+
+    #[test]
+    fn classify_never_offers_another_plugins_pane_as_spare() {
+        // The herdr-sidebar pane: no agent, but identity/heartbeat tokens. It
+        // must not become the pseudo-agent host — that is the pane-grab that
+        // put a second "agent" row in the panel.
+        let panes = [
+            pane_with_tokens("sidebar", &["herdr-sidebar-explorer", "herdr-sidebar-git"]),
+            pane("shell", "w1", None, None),
+        ];
+        let refs: Vec<&PaneInfo> = panes.iter().collect();
+        let roles = classify_panes(&refs);
+
+        assert_eq!(roles.spare_panes, ["shell"]);
+        assert!(roles.pseudo_panes.is_empty());
+        assert!(roles.agent_panes.is_empty());
+    }
+
+    #[test]
+    fn classify_keeps_a_pane_carrying_only_our_usage_token_as_spare() {
+        // The metadata fall-through pushes the `usage` token onto a spare pane
+        // WITHOUT claiming an agent; on the next cycle that pane must still be
+        // a spare pane, or the status would hop panes forever.
+        let panes = [pane_with_tokens("shell", &[PSEUDO_AGENT])];
+        let refs: Vec<&PaneInfo> = panes.iter().collect();
+        assert_eq!(classify_panes(&refs).spare_panes, ["shell"]);
+    }
+
+    #[test]
+    fn classify_prefers_the_real_agent_bucket_over_plugin_detection() {
+        // An agent pane with plugin badges (e.g. llmtrim tokens on a claude
+        // pane) stays an agent pane — the token check only gates spares.
+        let mut p = pane_with_tokens("claude", &["llmtrim"]);
+        p.agent = Some("claude".to_string());
+        let refs: Vec<&PaneInfo> = [&p].to_vec();
+        assert_eq!(classify_panes(&refs).agent_panes, ["claude"]);
     }
 
     /// Build a measured [`Space`] with just the aggregate-relevant fields set.

--- a/src/config.rs
+++ b/src/config.rs
@@ -135,8 +135,14 @@ fn home_dir() -> PathBuf {
         .unwrap_or_default()
 }
 
-/// XDG config base: `$XDG_CONFIG_HOME` if set (and non-empty), else `~/.config`.
+/// Config base: `%APPDATA%` on Windows (where the herdr beta keeps its config
+/// and socket), else `$XDG_CONFIG_HOME` if set (and non-empty), else
+/// `~/.config`.
 pub(crate) fn config_home() -> PathBuf {
+    #[cfg(windows)]
+    if let Some(appdata) = non_empty_env("APPDATA") {
+        return PathBuf::from(appdata);
+    }
     non_empty_env("XDG_CONFIG_HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|| home_dir().join(".config"))

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -47,12 +47,17 @@ pub struct Tracked {
 /// kernel later recycled for something else — and without it `--enable` would
 /// no-op forever against that impostor, leaving the sidebar permanently blank.
 pub fn daemon_pid() -> Option<u32> {
+    let pid = read_pid_file()?;
+    is_our_process(pid).then_some(pid)
+}
+
+/// The pid recorded in `<state_dir>/updater.pid`, or `None` if the file is
+/// missing, unparseable, or holds a non-positive pid. Says nothing about
+/// whether that process is alive — [`daemon_pid`] adds that.
+fn read_pid_file() -> Option<u32> {
     let text = std::fs::read_to_string(config::pid_file()).ok()?;
     let pid: i32 = text.trim().parse().ok()?;
-    if pid <= 0 {
-        return None;
-    }
-    is_our_process(pid as u32).then_some(pid as u32)
+    (pid > 0).then_some(pid as u32)
 }
 
 /// `--daemon`: run the updater loop until signalled, then clear and exit.
@@ -195,8 +200,15 @@ pub fn disable_updater() -> crate::Result<()> {
         // NOT done on unix — there the daemon unlinks it from its own SIGTERM
         // handler, and removing it out from under a daemon that is still
         // shutting down would let an immediate `--enable` start a second one.
+        //
+        // Guarded on the file still naming the pid we just stopped: a daemon
+        // started in the window between `daemon_pid` and here owns its own file
+        // and must keep it, or this would silently break its single-instance
+        // guard.
         #[cfg(windows)]
-        let _ = std::fs::remove_file(config::pid_file());
+        if read_pid_file() == Some(pid) {
+            let _ = std::fs::remove_file(config::pid_file());
+        }
     }
 
     // Belt and braces: sweep every current pane in case the daemon died — release
@@ -293,13 +305,20 @@ pub fn push_statuses(
         }
 
         // agents-panel fall-through: report the pane-level token on a spare/agent
-        // pane so the agents panel still shows the space. Two ways to get here —
-        // the pseudo pane closed between classification and the report, or the
-        // workspace offered no hostable pane at all because every agent-less one
-        // belongs to another plugin (see `collect::is_plugin_pane`). In the
-        // second case the space has no row of its own and its usage rides on a
-        // real agent's row instead; that is the deliberate cost of not
-        // hijacking someone else's pane.
+        // pane so the agents panel still shows the space. Three ways in, only
+        // the first of which used to be documented:
+        //   1. `report_agent` failed — the pseudo pane closed mid-cycle;
+        //   2. the space has only agent panes, so there was never a spare to
+        //      claim (true since long before the plugin-pane guard);
+        //   3. every agent-less pane belongs to another plugin and was filtered
+        //      out (see `collect::is_plugin_pane`).
+        // In 2 and 3 the space gets no row of its own and its usage rides on an
+        // agent's row instead. That is the designed agents-panel layout, not a
+        // hijack — `[ui.sidebar.agents]` expands `$usage` on the agent row — and
+        // it stays a token report: we never claim a pseudo-AGENT on a pane we
+        // do not own, which is the thing that grew a duplicate panel entry.
+        // If the space has no agent panes either, `targets` is empty and the
+        // space reports nothing this cycle; the next refresh re-evaluates.
         let targets = if !sp.spare_panes.is_empty() {
             &sp.spare_panes[..1]
         } else if !sp.agent_panes.is_empty() {
@@ -407,9 +426,26 @@ fn enabled_flag_set(path: &std::path::Path) -> bool {
 /// image name (`/proc/<pid>/comm` on Linux, the Toolhelp exe name on Windows)
 /// against our own.
 ///
-/// Guards pid reuse behind a stale pid file. Anything unreadable — a vanished
-/// process, or one owned by another user — reads as "not ours", which is the
-/// safe answer: we then treat the updater as down and start a fresh one.
+/// Guards pid reuse behind a stale pid file: a vanished process has no image
+/// name to read and so reads as "not ours", which is the safe answer — we then
+/// treat the updater as down and start a fresh one.
+///
+/// Two things this deliberately does NOT promise, both worth knowing before
+/// leaning on it:
+///
+/// - It is not an ownership check. `/proc/<pid>/comm` is world-readable, so
+///   another user's process of the same name matches. The old `kill(pid, 0)`
+///   probe rejected those with EPERM; it was dropped for a platform-neutral
+///   liveness check. Reach is narrow — herdr gives each user its own
+///   `HERDR_PLUGIN_STATE_DIR`, so a shared pid file needs the `<tmpdir>`
+///   fallback, i.e. the binary run outside herdr.
+/// - It cannot tell the daemon apart from our OTHER commands. `--interval`
+///   (the dashboard pane) and `--once` run the same executable, so a recycled
+///   pid landing on a live dashboard reads as a running daemon and makes
+///   `--enable` no-op until that pane closes. Pre-existing, on both platforms.
+///
+/// An advisory lock held on the pid file for the daemon's lifetime would settle
+/// both (`File::try_lock`, stable since 1.89) and is the recommended follow-up.
 fn is_our_process(pid: u32) -> bool {
     match (
         proc::process_image_name(pid),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14,7 +14,7 @@ use std::os::unix::process::CommandExt;
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
 use std::process::{Command, Stdio};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -106,10 +106,17 @@ pub fn run_daemon() -> crate::Result<()> {
         });
     }
 
+    // Windows-only backstop for the read timeout unix gets from the socket.
+    let started = std::time::Instant::now();
+    let heartbeat = Arc::new(AtomicU64::new(0));
+    #[cfg(windows)]
+    spawn_watchdog(Arc::clone(&heartbeat), started, config.interval_seconds);
+
     let daemon_interval_ms = config.interval_seconds * 1000;
     let mut window_ms: u64 = 500; // quick first sample so the sidebar updates immediately
     let mut failures: u32 = 0;
     loop {
+        heartbeat.store(started.elapsed().as_secs(), Ordering::SeqCst);
         match collect::snapshot(&mut client, window_ms) {
             Ok(spaces) => {
                 if stopping.load(Ordering::SeqCst) {
@@ -181,6 +188,15 @@ pub fn disable_updater() -> crate::Result<()> {
         // way down. Windows: TerminateProcess — abrupt, but the sweep below and
         // the status TTLs cover the cleanup the daemon can no longer do.
         proc::stop_process(pid);
+        // A terminated process runs no shutdown, so on Windows nothing would
+        // ever unlink the pid file: it outlives the daemon and leaves the
+        // recycled-pid check ([`is_our_process`]) as the only thing standing
+        // between a stale pid and a permanently no-op `--enable`. Deliberately
+        // NOT done on unix — there the daemon unlinks it from its own SIGTERM
+        // handler, and removing it out from under a daemon that is still
+        // shutting down would let an immediate `--enable` start a second one.
+        #[cfg(windows)]
+        let _ = std::fs::remove_file(config::pid_file());
     }
 
     // Belt and braces: sweep every current pane in case the daemon died — release
@@ -276,8 +292,14 @@ pub fn push_statuses(
             continue;
         }
 
-        // agents-panel fall-through only (the pseudo pane just closed): report the
-        // pane-level token on a spare/agent pane so the agents panel still shows it.
+        // agents-panel fall-through: report the pane-level token on a spare/agent
+        // pane so the agents panel still shows the space. Two ways to get here —
+        // the pseudo pane closed between classification and the report, or the
+        // workspace offered no hostable pane at all because every agent-less one
+        // belongs to another plugin (see `collect::is_plugin_pane`). In the
+        // second case the space has no row of its own and its usage rides on a
+        // real agent's row instead; that is the deliberate cost of not
+        // hijacking someone else's pane.
         let targets = if !sp.spare_panes.is_empty() {
             &sp.spare_panes[..1]
         } else if !sp.agent_panes.is_empty() {
@@ -420,6 +442,44 @@ fn park() -> ! {
     loop {
         thread::sleep(Duration::from_secs(3600));
     }
+}
+
+/// How long a sample may stall before the Windows watchdog gives up on it:
+/// generous, because a slow sample is normal and a false trip would kill a
+/// healthy updater. Only a host that has stopped answering entirely gets here.
+#[cfg(windows)]
+const WATCHDOG_GRACE: Duration = Duration::from_secs(300);
+
+/// Windows-only stand-in for the socket read timeout unix sets in
+/// [`crate::herdr`].
+///
+/// A named pipe opened as a `File` has no timeout knob, so a herdr that accepts
+/// the connection but never answers parks the sample loop inside `read_line`
+/// forever. Nothing recovers from that on its own: the failure counter never
+/// advances, so the five-failure shutdown never runs, the pid file is never
+/// released, and every later `--enable` / `--restore` sees a live pid and
+/// silently no-ops — the sidebar stays blank until someone finds the process by
+/// hand. The loop stamps `heartbeat` before each sample; if that stamp stops
+/// advancing, drop the pid file and exit so the statuses TTL out and the updater
+/// can be enabled again.
+#[cfg(windows)]
+fn spawn_watchdog(heartbeat: Arc<AtomicU64>, started: std::time::Instant, interval_seconds: u64) {
+    // At least the grace period, and always several intervals, so a long
+    // configured cadence cannot trip its own watchdog.
+    let deadline = WATCHDOG_GRACE
+        .as_secs()
+        .max(interval_seconds.saturating_mul(5));
+    thread::spawn(move || loop {
+        thread::sleep(Duration::from_secs(30));
+        let stalled = started
+            .elapsed()
+            .as_secs()
+            .saturating_sub(heartbeat.load(Ordering::SeqCst));
+        if stalled >= deadline {
+            let _ = std::fs::remove_file(config::pid_file());
+            std::process::exit(1);
+        }
+    });
 }
 
 /// Largest `ttl_ms` herdr accepts on `pane.report_metadata` /

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9,15 +9,15 @@
 //! restart when an `enabled` marker alongside the pid file says it was wanted.
 
 use std::collections::HashSet;
+#[cfg(unix)]
 use std::os::unix::process::CommandExt;
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
-
-use signal_hook::consts::{SIGINT, SIGTERM};
-use signal_hook::iterator::Signals;
 
 use crate::collect::{self, PSEUDO_AGENT};
 use crate::config::{self, Config, Labels, Mode};
@@ -40,20 +40,16 @@ pub struct Tracked {
 /// PID of a live updater daemon, or `None` (missing pid file / dead process /
 /// a pid that no longer belongs to us).
 ///
-/// Reads `<state_dir>/updater.pid`, probes the process with `kill(pid, 0)`
-/// (signal 0 checks existence only), and then confirms the pid really is one of
-/// our processes. That last check matters: the state dir outlives reboots, so an
-/// unclean shutdown can leave a pid file pointing at a pid the kernel later
-/// recycled for something else — and without it `--enable` would no-op forever
-/// against that impostor, leaving the sidebar permanently blank.
+/// Reads `<state_dir>/updater.pid` and confirms the pid is live AND really one
+/// of our processes ([`is_our_process`] answers both: a vanished pid has no
+/// image name to read). That second check matters: the state dir outlives
+/// reboots, so an unclean shutdown can leave a pid file pointing at a pid the
+/// kernel later recycled for something else — and without it `--enable` would
+/// no-op forever against that impostor, leaving the sidebar permanently blank.
 pub fn daemon_pid() -> Option<u32> {
     let text = std::fs::read_to_string(config::pid_file()).ok()?;
     let pid: i32 = text.trim().parse().ok()?;
     if pid <= 0 {
-        return None;
-    }
-    // SAFETY: `kill` with signal 0 performs no delivery, only a liveness probe.
-    if unsafe { libc::kill(pid, 0) } != 0 {
         return None;
     }
     is_our_process(pid as u32).then_some(pid as u32)
@@ -92,8 +88,15 @@ pub fn run_daemon() -> crate::Result<()> {
     // Signal thread: on the first SIGINT/SIGTERM, win the shutdown race and clear
     // everything via a fresh connection, then exit. The main loop must not
     // re-report after this runs, so it parks once it observes `stopping`.
-    let mut signals = Signals::new([SIGINT, SIGTERM])?;
+    // Windows has no equivalent graceful signal: `--disable` terminates the
+    // daemon outright there, and the pushed statuses self-clear via their TTL
+    // (plus `--disable`'s own sweep).
+    #[cfg(unix)]
     {
+        let mut signals = signal_hook::iterator::Signals::new([
+            signal_hook::consts::SIGINT,
+            signal_hook::consts::SIGTERM,
+        ])?;
         let stopping = Arc::clone(&stopping);
         let tracked = Arc::clone(&tracked);
         thread::spawn(move || {
@@ -174,11 +177,10 @@ pub fn disable_updater() -> crate::Result<()> {
     set_enabled(&config::enabled_flag(), false);
 
     if let Some(pid) = daemon_pid() {
-        // The daemon clears its own statuses + title on shutdown; best-effort.
-        // SAFETY: `kill` merely posts SIGTERM to the pid; failure is ignored.
-        unsafe {
-            libc::kill(pid as i32, SIGTERM);
-        }
+        // Unix: SIGTERM, and the daemon clears its own statuses + title on the
+        // way down. Windows: TerminateProcess — abrupt, but the sweep below and
+        // the status TTLs cover the cleanup the daemon can no longer do.
+        proc::stop_process(pid);
     }
 
     // Belt and braces: sweep every current pane in case the daemon died — release
@@ -330,9 +332,9 @@ pub fn set_title_totals(client: &mut Herdr, spaces: &[Space], labels: &Labels) {
 
 /// Re-exec ourselves as a detached `--daemon` process.
 ///
-/// Fully detached: a new session (setsid) so it survives the controlling
-/// terminal — which is what lets the daemon outlive the short-lived `--enable` /
-/// `--restore` command herdr spawned it from — and null stdio.
+/// Fully detached so it survives the short-lived `--enable` / `--restore`
+/// command herdr spawned it from: a new session (setsid) on unix; no console
+/// window and its own process group on Windows. Null stdio on both.
 fn spawn_daemon() -> crate::Result<()> {
     let exe = std::env::current_exe()?;
     let mut cmd = Command::new(exe);
@@ -342,13 +344,20 @@ fn spawn_daemon() -> crate::Result<()> {
         .stderr(Stdio::null());
     // SAFETY: `setsid` is async-signal-safe and the only action taken in the
     // forked child before exec; it starts a new session, detaching the daemon.
+    #[cfg(unix)]
     unsafe {
         cmd.pre_exec(|| match libc::setsid() {
             -1 => Err(std::io::Error::last_os_error()),
             _ => Ok(()),
         });
     }
-    cmd.spawn()?; // do not wait — the child outlives us and is reaped by init
+    // CREATE_NO_WINDOW (0x0800_0000): no console at all — a herdr hook child
+    // with a visible console flashes a window on Windows Terminal hosts.
+    // CREATE_NEW_PROCESS_GROUP (0x0000_0200): detaches Ctrl+C delivery from the
+    // spawning command's group.
+    #[cfg(windows)]
+    cmd.creation_flags(0x0800_0000 | 0x0000_0200);
+    cmd.spawn()?; // do not wait — the child outlives us
     Ok(())
 }
 
@@ -372,7 +381,8 @@ fn enabled_flag_set(path: &std::path::Path) -> bool {
     path.exists()
 }
 
-/// Whether `pid` is one of *our* processes, compared via `/proc/<pid>/comm`
+/// Whether `pid` is live and one of *our* processes, compared by executable
+/// image name (`/proc/<pid>/comm` on Linux, the Toolhelp exe name on Windows)
 /// against our own.
 ///
 /// Guards pid reuse behind a stale pid file. Anything unreadable — a vanished
@@ -380,19 +390,12 @@ fn enabled_flag_set(path: &std::path::Path) -> bool {
 /// safe answer: we then treat the updater as down and start a fresh one.
 fn is_our_process(pid: u32) -> bool {
     match (
-        comm_of(&format!("/proc/{pid}/comm")),
-        comm_of("/proc/self/comm"),
+        proc::process_image_name(pid),
+        proc::process_image_name(std::process::id()),
     ) {
         (Some(theirs), Some(ours)) => theirs == ours,
         _ => false,
     }
-}
-
-/// Trimmed contents of a `/proc/<pid>/comm` path, or `None` if unreadable.
-fn comm_of(path: &str) -> Option<String> {
-    std::fs::read_to_string(path)
-        .ok()
-        .map(|text| text.trim().to_string())
 }
 
 /// Clear tracked statuses + title, unlink the pid file, and `exit(0)`.
@@ -583,13 +586,8 @@ mod tests {
 
     #[test]
     fn vanished_pid_is_not_ours() {
-        // No `/proc/<pid>/comm` to read — the stale-pid-file case must read as
-        // "not ours" so the caller starts a fresh daemon.
+        // No image name to read for a dead pid — the stale-pid-file case must
+        // read as "not ours" so the caller starts a fresh daemon.
         assert!(!is_our_process(u32::MAX));
-    }
-
-    #[test]
-    fn comm_of_unreadable_path_is_none() {
-        assert_eq!(comm_of("/proc/nonexistent-pid/comm"), None);
     }
 }

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -73,12 +73,34 @@ fn open_stream(path: &Path) -> io::Result<Stream> {
     use std::os::windows::fs::OpenOptionsExt;
     use windows_sys::Win32::Storage::FileSystem::SECURITY_IDENTIFICATION;
 
-    let pipe = format!(r"\\.\pipe\{}", path.display());
     std::fs::OpenOptions::new()
         .read(true)
         .write(true)
         .security_qos_flags(SECURITY_IDENTIFICATION)
-        .open(pipe)
+        .open(pipe_name(path))
+}
+
+/// herdr's socket path folded into a named-pipe name. interprocess' namespaced
+/// naming puts the WHOLE path after the prefix, drive letter and separators
+/// included, so this is a plain concatenation and not a basename.
+#[cfg(windows)]
+fn pipe_name(path: &Path) -> String {
+    format!(r"\\.\pipe\{}", path.display())
+}
+
+/// What we actually open, named for error messages.
+///
+/// Worth the indirection: on Windows the connection is to a pipe, not to the
+/// file the path spells. Reporting the raw path there sends a user hunting for
+/// a `herdr.sock` file that neither exists nor should — and since the pipe-name
+/// construction is the one part of the Windows transport no automated test can
+/// exercise (CI has no herdr to talk to), its failure has to name the thing it
+/// actually tried.
+fn endpoint(path: &Path) -> String {
+    #[cfg(windows)]
+    return pipe_name(path);
+    #[cfg(unix)]
+    path.display().to_string()
 }
 
 use crate::model::{
@@ -113,7 +135,7 @@ impl Herdr {
     /// Connect to `path` and wire up the read/write halves.
     fn open(path: PathBuf) -> crate::Result<Herdr> {
         let stream = open_stream(&path)
-            .map_err(|e| format!("cannot connect to herdr socket {}: {e}", path.display()))?;
+            .map_err(|e| format!("cannot connect to herdr at {}: {e}", endpoint(&path)))?;
         let reader = BufReader::new(stream.try_clone()?);
         Ok(Herdr {
             stream,
@@ -125,12 +147,8 @@ impl Herdr {
 
     /// Re-open the socket after a broken pipe, replacing both halves.
     fn reconnect(&mut self) -> crate::Result<()> {
-        let stream = open_stream(&self.path).map_err(|e| {
-            format!(
-                "cannot reconnect to herdr socket {}: {e}",
-                self.path.display()
-            )
-        })?;
+        let stream = open_stream(&self.path)
+            .map_err(|e| format!("cannot reconnect to herdr at {}: {e}", endpoint(&self.path)))?;
         self.reader = BufReader::new(stream.try_clone()?);
         self.stream = stream;
         Ok(())
@@ -522,5 +540,27 @@ mod tests {
             socket_path_from(None, config_home),
             PathBuf::from("/home/u/.config/herdr/herdr.sock"),
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn pipe_name_folds_the_whole_path_after_the_prefix() {
+        // Pins the one piece of the Windows transport nothing else can check:
+        // CI has no herdr to connect to, so a silent change to this format
+        // would only ever surface as "cannot connect" on a user's machine.
+        // interprocess' namespaced naming keeps the drive letter and every
+        // separator — it is NOT the basename.
+        assert_eq!(
+            pipe_name(Path::new(r"C:\Users\u\AppData\Roaming\herdr\herdr.sock")),
+            r"\\.\pipe\C:\Users\u\AppData\Roaming\herdr\herdr.sock",
+        );
+        // The error path must name the pipe, not the file that never exists.
+        assert!(endpoint(Path::new(r"C:\x\herdr.sock")).starts_with(r"\\.\pipe\"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn endpoint_is_the_plain_socket_path() {
+        assert_eq!(endpoint(Path::new("/run/herdr.sock")), "/run/herdr.sock");
     }
 }

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -18,15 +18,54 @@
 //!
 //! The socket path is resolved `HERDR_SOCKET_PATH` → `$XDG_CONFIG_HOME/herdr` →
 //! `~/.config/herdr/herdr.sock` (the XDG/home resolution is reused from
-//! [`crate::config`]).
+//! [`crate::config`]; on Windows the config home is `%APPDATA%`). On unix the
+//! transport is a persistent `UnixStream`; on Windows the same value names a
+//! pipe (`\\.\pipe\<path>`) opened as a read+write `File` — see [`open_stream`].
 
 use std::io::{self, BufRead, BufReader, Write};
+#[cfg(unix)]
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
+#[cfg(unix)]
 use std::time::Duration;
 
 use serde::Serialize;
 use serde_json::{json, Value};
+
+/// The platform transport speaking herdr's newline-delimited JSON-RPC.
+///
+/// unix: a unix domain socket. windows: herdr (via interprocess' namespaced
+/// naming) exposes the socket as a named pipe at `\\.\pipe\<HERDR_SOCKET_PATH>`
+/// — the WHOLE path is folded into the pipe name — and an ordinary
+/// read+write `File` can speak it (same pattern as herdr-sidebar's ipc.rs,
+/// verified on the herdr 0.8 Windows beta).
+#[cfg(unix)]
+type Stream = UnixStream;
+#[cfg(windows)]
+type Stream = std::fs::File;
+
+/// Connect the platform stream to the herdr socket at `path`.
+#[cfg(unix)]
+fn open_stream(path: &Path) -> io::Result<Stream> {
+    let stream = UnixStream::connect(path)?;
+    stream.set_read_timeout(Some(IO_TIMEOUT))?;
+    stream.set_write_timeout(Some(IO_TIMEOUT))?;
+    Ok(stream)
+}
+
+/// Connect the platform stream to the herdr socket at `path`.
+///
+/// No read/write timeouts: a pipe opened as `File` has no such knobs. herdr
+/// answers in milliseconds; a wedged host is the only hang, as on unix when the
+/// timeout fires late.
+#[cfg(windows)]
+fn open_stream(path: &Path) -> io::Result<Stream> {
+    let pipe = format!(r"\\.\pipe\{}", path.display());
+    std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(pipe)
+}
 
 use crate::model::{
     ProcessInfo, ProcessInfoResult, SessionSnapshot, SessionSnapshotResult, WorktreeListResult,
@@ -34,15 +73,16 @@ use crate::model::{
 
 /// Read/write timeout for a single JSON-RPC round-trip. Generous — herdr answers
 /// in milliseconds; this only guards against a wedged host hanging the plugin.
+#[cfg(unix)]
 const IO_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// A live JSON-RPC connection to the herdr host.
 pub struct Herdr {
     /// Write half — requests are written here and flushed.
-    stream: UnixStream,
+    stream: Stream,
     /// Read half — a `BufReader` over a cloned fd so we can `read_line` while the
     /// write half stays borrowable.
-    reader: BufReader<UnixStream>,
+    reader: BufReader<Stream>,
     /// Socket path, retained so a broken connection can be re-opened.
     path: PathBuf,
     /// Monotonic request id counter (unique per connection, and across reconnects
@@ -58,9 +98,8 @@ pub fn connect() -> crate::Result<Herdr> {
 impl Herdr {
     /// Connect to `path` and wire up the read/write halves.
     fn open(path: PathBuf) -> crate::Result<Herdr> {
-        let stream = UnixStream::connect(&path)
+        let stream = open_stream(&path)
             .map_err(|e| format!("cannot connect to herdr socket {}: {e}", path.display()))?;
-        configure(&stream)?;
         let reader = BufReader::new(stream.try_clone()?);
         Ok(Herdr {
             stream,
@@ -72,13 +111,12 @@ impl Herdr {
 
     /// Re-open the socket after a broken pipe, replacing both halves.
     fn reconnect(&mut self) -> crate::Result<()> {
-        let stream = UnixStream::connect(&self.path).map_err(|e| {
+        let stream = open_stream(&self.path).map_err(|e| {
             format!(
                 "cannot reconnect to herdr socket {}: {e}",
                 self.path.display()
             )
         })?;
-        configure(&stream)?;
         self.reader = BufReader::new(stream.try_clone()?);
         self.stream = stream;
         Ok(())
@@ -354,18 +392,15 @@ fn parse_envelope(line: &str) -> crate::Result<Value> {
 
 /// Socket path from an optional `HERDR_SOCKET_PATH` override and the resolved
 /// config home: the override wins, else `<config_home>/herdr/herdr.sock`.
+///
+/// On Windows the config home resolves to `%APPDATA%` (see
+/// [`crate::config::config_home`]), matching where the herdr beta puts
+/// `herdr\herdr.sock`; the value then names the pipe (see [`open_stream`]).
 fn socket_path_from(explicit: Option<&str>, config_home: &Path) -> PathBuf {
     match explicit {
         Some(path) => PathBuf::from(path),
         None => config_home.join("herdr").join("herdr.sock"),
     }
-}
-
-/// Apply the round-trip read/write timeouts to a freshly connected stream.
-fn configure(stream: &UnixStream) -> io::Result<()> {
-    stream.set_read_timeout(Some(IO_TIMEOUT))?;
-    stream.set_write_timeout(Some(IO_TIMEOUT))?;
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -55,15 +55,29 @@ fn open_stream(path: &Path) -> io::Result<Stream> {
 
 /// Connect the platform stream to the herdr socket at `path`.
 ///
-/// No read/write timeouts: a pipe opened as `File` has no such knobs. herdr
-/// answers in milliseconds; a wedged host is the only hang, as on unix when the
-/// timeout fires late.
+/// `SECURITY_IDENTIFICATION` is not optional. A named pipe lives in a global
+/// namespace that any local account may create names in, and our name is
+/// guessable (it embeds `%APPDATA%`, which contains the user name). Without an
+/// explicit SQOS level Windows hands the pipe SERVER `SecurityImpersonation`,
+/// so a local attacker who squats the name before herdr binds it can call
+/// `ImpersonateNamedPipeClient` and act as whoever runs this plugin.
+/// `SecurityIdentification` lets the server learn who we are but never act as
+/// us, which is all herdr needs to serve JSON-RPC. std ORs in
+/// `SECURITY_SQOS_PRESENT` for us, and without that flag the level is ignored.
+///
+/// No read/write timeouts: a pipe opened as `File` has no such knobs. That is
+/// the one thing unix gets for free here, so the daemon carries a watchdog
+/// instead — see [`crate::daemon::run_daemon`].
 #[cfg(windows)]
 fn open_stream(path: &Path) -> io::Result<Stream> {
+    use std::os::windows::fs::OpenOptionsExt;
+    use windows_sys::Win32::Storage::FileSystem::SECURITY_IDENTIFICATION;
+
     let pipe = format!(r"\\.\pipe\{}", path.display());
     std::fs::OpenOptions::new()
         .read(true)
         .write(true)
+        .security_qos_flags(SECURITY_IDENTIFICATION)
         .open(pipe)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,13 +16,18 @@
 //!                     herdr/machine restart if the updater was enabled
 //!   --daemon          internal: run the updater loop (spawned by --enable)
 //!
-//! Linux-only: relies on `/proc`. herdr injects HERDR_BIN_PATH / HERDR_PLUGIN_*.
+//! Linux and Windows: the `proc` module reads `/proc` on Linux and the Win32
+//! process APIs on Windows. herdr injects HERDR_BIN_PATH / HERDR_PLUGIN_*.
 
 mod collect;
 mod config;
 mod daemon;
 mod herdr;
 mod model;
+#[cfg(unix)]
+mod proc;
+#[cfg(windows)]
+#[path = "proc_windows.rs"]
 mod proc;
 mod render;
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -77,7 +77,10 @@ pub struct WorkspaceInfo {
 }
 
 /// One entry of `panes`; only the fields we consume are modelled. `workspace_id`
-/// is what buckets each pane back under its workspace.
+/// is what buckets each pane back under its workspace. `tokens` is the pane's
+/// metadata-token map (`pane.report_metadata`): panes opened by other plugins
+/// stamp their identity there (e.g. herdr-sidebar's heartbeat), which is how
+/// the classifier keeps its status row off them.
 #[derive(Debug, Clone, Deserialize)]
 pub struct PaneInfo {
     pub pane_id: String,
@@ -87,6 +90,8 @@ pub struct PaneInfo {
     pub cwd: Option<String>,
     #[serde(default)]
     pub agent: Option<String>,
+    #[serde(default)]
+    pub tokens: Option<std::collections::HashMap<String, serde_json::Value>>,
 }
 
 // ---- pane.process_info ------------------------------------------------------
@@ -168,7 +173,9 @@ mod tests {
             "agent_status": "working", "revision": 1 },
           { "pane_id": "wT:p1", "terminal_id": "t3", "workspace_id": "wT",
             "tab_id": "wT:t1", "focused": false, "cwd": null,
-            "agent_status": "unknown", "revision": 0 }
+            "agent_status": "unknown", "revision": 0,
+            "tokens": { "herdr-sidebar-explorer": "1785860662",
+                        "herdr-sidebar-git": "1785860662" } }
         ],
         "layouts": [],
         "agents": []
@@ -195,6 +202,10 @@ mod tests {
         // An explicit `null` cwd must not be an error — herdr can omit it while a
         // pane is still starting.
         assert_eq!(snap.panes[2].cwd, None);
+        // Plugin panes surface their identity tokens; plain panes have none.
+        assert!(snap.panes[0].tokens.is_none());
+        let tokens = snap.panes[2].tokens.as_ref().expect("sidebar pane tokens");
+        assert!(tokens.contains_key("herdr-sidebar-explorer"));
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -81,6 +81,13 @@ pub struct WorkspaceInfo {
 /// metadata-token map (`pane.report_metadata`): panes opened by other plugins
 /// stamp their identity there (e.g. herdr-sidebar's heartbeat), which is how
 /// the classifier keeps its status row off them.
+///
+/// Typed `String -> String` to match the schema exactly (`PaneInfo.tokens` is
+/// `map<string,string>`, keys `^[A-Za-z0-9_-]{1,32}$`) so a schema change lands
+/// as a parse error here rather than being silently swallowed by a `Value`.
+/// Note the map is FLAT across every reporting plugin — herdr attributes no
+/// source to it — which is what makes [`crate::collect`]'s ownership check a
+/// heuristic rather than a guarantee.
 #[derive(Debug, Clone, Deserialize)]
 pub struct PaneInfo {
     pub pane_id: String,
@@ -91,7 +98,7 @@ pub struct PaneInfo {
     #[serde(default)]
     pub agent: Option<String>,
     #[serde(default)]
-    pub tokens: Option<std::collections::HashMap<String, serde_json::Value>>,
+    pub tokens: Option<std::collections::HashMap<String, String>>,
 }
 
 // ---- pane.process_info ------------------------------------------------------

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -170,6 +170,24 @@ pub fn rss_mb(pids: &HashSet<u32>) -> f64 {
     bytes as f64 / (1024.0 * 1024.0)
 }
 
+/// Executable name of `pid` from `/proc/<pid>/comm`, or `None` when the process
+/// is gone or unreadable. Used by the daemon's stale-pid-file guard; also
+/// doubles as the liveness probe (a vanished pid has no `comm` to read).
+pub fn process_image_name(pid: u32) -> Option<String> {
+    std::fs::read_to_string(format!("/proc/{pid}/comm"))
+        .ok()
+        .map(|text| text.trim().to_string())
+}
+
+/// Best-effort graceful stop of `pid` via SIGTERM (failure is ignored — the
+/// daemon's statuses self-clear via their TTL either way).
+pub fn stop_process(pid: u32) {
+    // SAFETY: `kill` merely posts SIGTERM to the pid.
+    unsafe {
+        libc::kill(pid as i32, libc::SIGTERM);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -264,4 +264,39 @@ mod tests {
         assert_eq!(parse_mem_total_mb(meminfo), Some(16.0)); // 16384 / 1024
         assert_eq!(parse_mem_total_mb("MemFree: 10 kB\n"), None);
     }
+
+    // ---- live-machine probes (mirrored by the proc_windows.rs twin) ---------
+
+    #[test]
+    fn own_image_name_is_reported_and_vanished_pid_is_none() {
+        let name = process_image_name(std::process::id()).expect("own image name");
+        assert!(!name.is_empty());
+        // The stale-pid-file case: nothing to read for a dead pid. This is also
+        // the liveness half of `daemon::is_our_process`.
+        assert_eq!(process_image_name(u32::MAX), None);
+    }
+
+    #[test]
+    fn scan_includes_our_own_process_with_a_parent() {
+        let procs = scan_proc();
+        let me = procs
+            .get(&std::process::id())
+            .expect("our own pid is in the scan");
+        assert!(me.ppid > 0, "our parent pid should be a real process");
+    }
+
+    #[test]
+    fn stop_process_terminates_a_child() {
+        // A child we own, doing nothing, so the only thing that can end it is
+        // our SIGTERM. `sleep` is in POSIX and always present.
+        let mut child = std::process::Command::new("sleep")
+            .arg("300")
+            .spawn()
+            .expect("spawn sleep");
+        stop_process(child.id());
+        // `wait` reaps it; without the signal landing this blocks for 300 s and
+        // the test times out, which is the failure we want to see.
+        let status = child.wait().expect("wait for sleep");
+        assert!(!status.success(), "a SIGTERMed child must not exit cleanly");
+    }
 }

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -188,6 +188,37 @@ pub fn stop_process(pid: u32) {
     }
 }
 
+/// Shared by the two platform twins' `stop_process` tests: stop `child` and
+/// require it to actually be gone soon after. (Mirrored in `proc_windows.rs` —
+/// the twins are compiled exclusively, so their common helpers are duplicated
+/// rather than shared, same as `subtree` / `children_map` / `pct_string`.)
+///
+/// Polls rather than blocking in `wait`, so a `stop_process` that does nothing
+/// fails the test in seconds instead of hanging until the CI job times out, and
+/// the child is always reaped either way. Says nothing about the exit status —
+/// the platforms disagree there (unix reports the signal, Windows reports the
+/// exit code TerminateProcess was given, which is 0).
+#[cfg(test)]
+pub(crate) fn assert_stopped_promptly(mut child: std::process::Child) {
+    use std::time::{Duration, Instant};
+
+    stop_process(child.id());
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut exited = false;
+    while Instant::now() < deadline {
+        if child.try_wait().expect("try_wait on child").is_some() {
+            exited = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    if !exited {
+        let _ = child.kill(); // never leave a 5-minute process behind
+        let _ = child.wait();
+    }
+    assert!(exited, "stop_process did not terminate the child");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -289,14 +320,10 @@ mod tests {
     fn stop_process_terminates_a_child() {
         // A child we own, doing nothing, so the only thing that can end it is
         // our SIGTERM. `sleep` is in POSIX and always present.
-        let mut child = std::process::Command::new("sleep")
+        let child = std::process::Command::new("sleep")
             .arg("300")
             .spawn()
             .expect("spawn sleep");
-        stop_process(child.id());
-        // `wait` reaps it; without the signal landing this blocks for 300 s and
-        // the test times out, which is the failure we want to see.
-        let status = child.wait().expect("wait for sleep");
-        assert!(!status.success(), "a SIGTERMed child must not exit cleanly");
+        assert_stopped_promptly(child);
     }
 }

--- a/src/proc_windows.rs
+++ b/src/proc_windows.rs
@@ -259,6 +259,35 @@ pub fn rss_mb(pids: &HashSet<u32>) -> f64 {
     bytes as f64 / (1024.0 * 1024.0)
 }
 
+/// Shared by the two platform twins' `stop_process` tests: stop `child` and
+/// require it to actually be gone soon after.
+///
+/// Polls rather than blocking in `wait`, so a `stop_process` that does nothing
+/// fails the test in seconds instead of hanging until the CI job times out, and
+/// the child is always reaped either way. Says nothing about the exit status —
+/// the platforms disagree there (unix reports the signal, Windows reports the
+/// exit code TerminateProcess was given).
+#[cfg(test)]
+pub(crate) fn assert_stopped_promptly(mut child: std::process::Child) {
+    use std::time::{Duration, Instant};
+
+    stop_process(child.id());
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut exited = false;
+    while Instant::now() < deadline {
+        if child.try_wait().expect("try_wait on child").is_some() {
+            exited = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    if !exited {
+        let _ = child.kill(); // never leave a 5-minute process behind
+        let _ = child.wait();
+    }
+    assert!(exited, "stop_process did not terminate the child");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -332,19 +361,16 @@ mod tests {
         // A child we own that does nothing but wait, so the only thing that can
         // end it is our TerminateProcess. `ping` ships with every Windows SKU
         // and paces one echo per second.
-        let mut child = std::process::Command::new("ping")
+        let child = std::process::Command::new("ping")
             .args(["-n", "300", "127.0.0.1"])
             .stdout(std::process::Stdio::null())
             .spawn()
             .expect("spawn ping");
-        stop_process(child.id());
-        // `wait` reaps it; without the terminate landing this blocks for ~300 s
-        // and the test times out, which is the failure we want to see.
-        let status = child.wait().expect("wait for ping");
-        assert!(
-            !status.success(),
-            "a terminated child must not exit cleanly"
-        );
+        // Asserted by "did it die", NOT by exit status: `stop_process` calls
+        // TerminateProcess with exit code 0, so a killed process is
+        // indistinguishable from a clean one by `ExitStatus::success` — unlike
+        // unix, where a SIGTERMed child reports the signal.
+        assert_stopped_promptly(child);
     }
 
     #[test]

--- a/src/proc_windows.rs
+++ b/src/proc_windows.rs
@@ -20,8 +20,8 @@ use windows_sys::Win32::System::Diagnostics::ToolHelp::{
 use windows_sys::Win32::System::ProcessStatus::{K32GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS};
 use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
 use windows_sys::Win32::System::Threading::{
-    GetProcessTimes, OpenProcess, TerminateProcess, PROCESS_QUERY_LIMITED_INFORMATION,
-    PROCESS_TERMINATE,
+    GetActiveProcessorCount, GetProcessTimes, OpenProcess, TerminateProcess, ALL_PROCESSOR_GROUPS,
+    PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE,
 };
 
 /// Per-process sample: parent PID and cumulative CPU time in [`clk_tck`] units
@@ -40,11 +40,18 @@ pub fn clk_tck() -> u64 {
 
 /// Number of logical CPUs; normalizes CPU% to a share of the whole machine.
 /// At least 1.
+///
+/// `GetActiveProcessorCount(ALL_PROCESSOR_GROUPS)`, NOT
+/// `available_parallelism()`. The metric is a share of the WHOLE MACHINE, to
+/// match the Linux twin's `_SC_NPROCESSORS_ONLN`, and `available_parallelism`
+/// answers a different question: it honours the process affinity mask and job
+/// CPU limits, and counts only the caller's processor group — so on a box with
+/// more than 64 logical CPUs it saturates at 64 and every reported CPU% comes
+/// out inflated by the ratio.
 pub fn nproc() -> u64 {
-    std::thread::available_parallelism()
-        .map(|n| n.get() as u64)
-        .unwrap_or(1)
-        .max(1)
+    // SAFETY: a pure query of a static system value.
+    let n = unsafe { GetActiveProcessorCount(ALL_PROCESSOR_GROUPS) };
+    (n as u64).max(1)
 }
 
 /// An open process handle that closes itself on drop; `None` when the process
@@ -298,11 +305,43 @@ mod tests {
     #[test]
     fn scan_includes_our_own_process_with_cpu_ticks() {
         let procs = scan_proc();
-        let me = procs
-            .get(&std::process::id())
-            .expect("our own pid is in the snapshot");
-        // Our own process is always openable, so its CPU counter is real.
-        assert!(me.jiffies > 0, "own cumulative CPU ticks read as zero");
+        assert!(
+            procs.contains_key(&std::process::id()),
+            "our own pid is in the snapshot"
+        );
+
+        // Our own process is always openable, so the counter is readable. It is
+        // NOT asserted non-zero straight away: `GetProcessTimes` is only charged
+        // on ~15.6 ms scheduler ticks, so a young test binary can legitimately
+        // still read zero. Burn CPU until the kernel charges us, with a deadline
+        // so a genuinely broken probe fails instead of hanging.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let mut ticks = 0;
+        while ticks == 0 && std::time::Instant::now() < deadline {
+            ticks = cpu_ticks(std::process::id()).expect("own cpu ticks are readable");
+            std::hint::black_box((0..200_000u64).sum::<u64>());
+        }
+        assert!(ticks > 0, "own cumulative CPU ticks never left zero");
+    }
+
+    #[test]
+    fn stop_process_terminates_a_child() {
+        // A child we own that does nothing but wait, so the only thing that can
+        // end it is our TerminateProcess. `ping` ships with every Windows SKU
+        // and paces one echo per second.
+        let mut child = std::process::Command::new("ping")
+            .args(["-n", "300", "127.0.0.1"])
+            .stdout(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn ping");
+        stop_process(child.id());
+        // `wait` reaps it; without the terminate landing this blocks for ~300 s
+        // and the test times out, which is the failure we want to see.
+        let status = child.wait().expect("wait for ping");
+        assert!(
+            !status.success(),
+            "a terminated child must not exit cleanly"
+        );
     }
 
     #[test]
@@ -315,6 +354,22 @@ mod tests {
     #[test]
     fn machine_ram_total_is_positive() {
         assert!(mem_total_mb() > 0.0);
+    }
+
+    #[test]
+    fn nproc_counts_the_whole_machine() {
+        let n = nproc();
+        assert!(n >= 1, "nproc must never report zero");
+        // The machine-wide count can only be >= what this process is allowed to
+        // run on; `available_parallelism` is the affinity-limited, single-group
+        // answer this function deliberately does NOT use.
+        let affinity = std::thread::available_parallelism()
+            .map(|n| n.get() as u64)
+            .unwrap_or(1);
+        assert!(
+            n >= affinity,
+            "machine-wide count {n} is below the affinity-limited {affinity}"
+        );
     }
 
     #[test]

--- a/src/proc_windows.rs
+++ b/src/proc_windows.rs
@@ -1,0 +1,325 @@
+//! Windows process sampling — the `proc` module twin of the Linux `/proc` reader.
+//!
+//! Same public surface as `proc.rs`, different probes: the process table comes
+//! from a Toolhelp32 snapshot (pid + ppid), cumulative CPU time from
+//! `GetProcessTimes` (kernel + user, in 100 ns FILETIME ticks — so [`clk_tck`]
+//! is 10^7), RSS from `K32GetProcessMemoryInfo` (working set), and the machine
+//! total from `GlobalMemoryStatusEx`. Processes we cannot open (other users,
+//! protected system processes) still contribute their pid/ppid edge — the
+//! subtree walk needs the topology even when the counters are unreadable — but
+//! sample as zero CPU/RSS, which is correct for panes we own: a herdr pane's
+//! subtree runs as the current user.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+
+use windows_sys::Win32::Foundation::{CloseHandle, FILETIME, HANDLE, INVALID_HANDLE_VALUE};
+use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+    CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W, TH32CS_SNAPPROCESS,
+};
+use windows_sys::Win32::System::ProcessStatus::{K32GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS};
+use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
+use windows_sys::Win32::System::Threading::{
+    GetProcessTimes, OpenProcess, TerminateProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    PROCESS_TERMINATE,
+};
+
+/// Per-process sample: parent PID and cumulative CPU time in [`clk_tck`] units
+/// (here FILETIME 100 ns ticks; the Linux twin uses jiffies — the shared math in
+/// `collect::measure` divides by [`clk_tck`] so both come out as seconds).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ProcEntry {
+    pub ppid: u32,
+    pub jiffies: u64,
+}
+
+/// CPU-time units per second: FILETIME ticks are 100 ns.
+pub fn clk_tck() -> u64 {
+    10_000_000
+}
+
+/// Number of logical CPUs; normalizes CPU% to a share of the whole machine.
+/// At least 1.
+pub fn nproc() -> u64 {
+    std::thread::available_parallelism()
+        .map(|n| n.get() as u64)
+        .unwrap_or(1)
+        .max(1)
+}
+
+/// An open process handle that closes itself on drop; `None` when the process
+/// cannot be opened with `access` (gone, or not ours to query).
+struct Process(HANDLE);
+
+impl Process {
+    fn open(pid: u32, access: u32) -> Option<Process> {
+        // SAFETY: `OpenProcess` is a pure acquisition call; a null handle means
+        // failure and is mapped to `None`.
+        let handle = unsafe { OpenProcess(access, 0, pid) };
+        if handle.is_null() {
+            None
+        } else {
+            Some(Process(handle))
+        }
+    }
+}
+
+impl Drop for Process {
+    fn drop(&mut self) {
+        // SAFETY: the handle was returned live by `OpenProcess`.
+        unsafe { CloseHandle(self.0) };
+    }
+}
+
+/// `FILETIME` (two 32-bit halves) to one u64 of 100 ns ticks.
+fn filetime_ticks(ft: &FILETIME) -> u64 {
+    ((ft.dwHighDateTime as u64) << 32) | ft.dwLowDateTime as u64
+}
+
+/// Cumulative kernel+user CPU ticks for `pid`, or `None` when unreadable.
+fn cpu_ticks(pid: u32) -> Option<u64> {
+    let process = Process::open(pid, PROCESS_QUERY_LIMITED_INFORMATION)?;
+    let mut creation = FILETIME {
+        dwLowDateTime: 0,
+        dwHighDateTime: 0,
+    };
+    let mut exit = FILETIME {
+        dwLowDateTime: 0,
+        dwHighDateTime: 0,
+    };
+    let mut kernel = FILETIME {
+        dwLowDateTime: 0,
+        dwHighDateTime: 0,
+    };
+    let mut user = FILETIME {
+        dwLowDateTime: 0,
+        dwHighDateTime: 0,
+    };
+    // SAFETY: all four out-params are valid caller-owned FILETIMEs.
+    let ok =
+        unsafe { GetProcessTimes(process.0, &mut creation, &mut exit, &mut kernel, &mut user) };
+    (ok != 0).then(|| filetime_ticks(&kernel) + filetime_ticks(&user))
+}
+
+/// One pass over the Toolhelp32 process snapshot, yielding each entry.
+fn for_each_process(mut f: impl FnMut(&PROCESSENTRY32W)) {
+    // SAFETY: TH32CS_SNAPPROCESS snapshots are a documented read-only query.
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return;
+    }
+    let mut entry: PROCESSENTRY32W = unsafe { std::mem::zeroed() };
+    entry.dwSize = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+    // SAFETY: `entry` is a properly sized PROCESSENTRY32W for both calls.
+    unsafe {
+        if Process32FirstW(snapshot, &mut entry) != 0 {
+            loop {
+                f(&entry);
+                if Process32NextW(snapshot, &mut entry) == 0 {
+                    break;
+                }
+            }
+        }
+        CloseHandle(snapshot);
+    }
+}
+
+/// Snapshot the process table once, returning `pid -> {ppid, cpu ticks}` for
+/// every live process. Unopenable processes keep their pid/ppid edge (the
+/// subtree walk needs it) with zero ticks.
+pub fn scan_proc() -> HashMap<u32, ProcEntry> {
+    let mut procs = HashMap::new();
+    for_each_process(|entry| {
+        let pid = entry.th32ProcessID;
+        if pid == 0 {
+            return; // the System Idle pseudo-process is not a real root
+        }
+        procs.insert(
+            pid,
+            ProcEntry {
+                ppid: entry.th32ParentProcessID,
+                jiffies: cpu_ticks(pid).unwrap_or(0),
+            },
+        );
+    });
+    procs
+}
+
+/// Executable file name (e.g. `space-usage.exe`) of `pid`, or `None` when the
+/// process is gone. Used by the daemon's stale-pid-file guard.
+pub fn process_image_name(pid: u32) -> Option<String> {
+    let mut found = None;
+    for_each_process(|entry| {
+        if entry.th32ProcessID == pid {
+            let len = entry
+                .szExeFile
+                .iter()
+                .position(|&c| c == 0)
+                .unwrap_or(entry.szExeFile.len());
+            found = Some(String::from_utf16_lossy(&entry.szExeFile[..len]));
+        }
+    });
+    found
+}
+
+/// Best-effort stop of `pid` (the Windows stand-in for SIGTERM). Statuses the
+/// daemon pushed self-clear via their TTL, and `--disable` sweeps them anyway,
+/// so an abrupt termination loses nothing.
+pub fn stop_process(pid: u32) {
+    if let Some(process) = Process::open(pid, PROCESS_TERMINATE) {
+        // SAFETY: terminating a handle we own with PROCESS_TERMINATE access.
+        unsafe { TerminateProcess(process.0, 0) };
+    }
+}
+
+/// Invert a proc map into `ppid -> [child pid, ..]`.
+pub fn children_map(procs: &HashMap<u32, ProcEntry>) -> HashMap<u32, Vec<u32>> {
+    let mut kids: HashMap<u32, Vec<u32>> = HashMap::new();
+    for (&pid, p) in procs {
+        kids.entry(p.ppid).or_default().push(pid);
+    }
+    kids
+}
+
+/// Every PID in `root`'s process subtree (inclusive), via the children map.
+/// Iterative DFS with a visited set, so shared parents and cycles terminate.
+/// (Windows recycles PIDs aggressively, so parent links can genuinely cycle.)
+pub fn subtree(root: u32, kids: &HashMap<u32, Vec<u32>>) -> HashSet<u32> {
+    let mut out = HashSet::new();
+    let mut stack = vec![root];
+    while let Some(pid) = stack.pop() {
+        if !out.insert(pid) {
+            continue; // already visited — dedup
+        }
+        if let Some(children) = kids.get(&pid) {
+            stack.extend(children.iter().copied());
+        }
+    }
+    out
+}
+
+/// Total physical RAM in MB via `GlobalMemoryStatusEx` (0 if the call fails).
+/// Read once and cached for the process lifetime.
+pub fn mem_total_mb() -> f64 {
+    static MEM_TOTAL_MB: OnceLock<f64> = OnceLock::new();
+    *MEM_TOTAL_MB.get_or_init(|| {
+        let mut status: MEMORYSTATUSEX = unsafe { std::mem::zeroed() };
+        status.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+        // SAFETY: `status` is a properly sized MEMORYSTATUSEX.
+        if unsafe { GlobalMemoryStatusEx(&mut status) } != 0 {
+            status.ullTotalPhys as f64 / (1024.0 * 1024.0)
+        } else {
+            0.0
+        }
+    })
+}
+
+/// Render `mb` as a whole-percent-of-`total_mb` string, or `""` when unknown.
+fn pct_string(mb: f64, total_mb: f64) -> String {
+    if total_mb > 0.0 {
+        // `round()` is half-away-from-zero, which for these non-negative
+        // values is ordinary half-up rounding.
+        format!("{}%", (100.0 * mb / total_mb).round() as i64)
+    } else {
+        String::new()
+    }
+}
+
+/// `"<n>%"` of total system RAM for `mb`, or `""` if the total is unknown.
+pub fn ram_pct(mb: f64) -> String {
+    pct_string(mb, mem_total_mb())
+}
+
+/// Sum of resident memory (MB) across `pids` — working set size per
+/// `K32GetProcessMemoryInfo`, the closest Windows analogue of Linux RSS.
+/// Vanished or unopenable pids contribute nothing.
+pub fn rss_mb(pids: &HashSet<u32>) -> f64 {
+    let mut bytes: u64 = 0;
+    for &pid in pids {
+        let Some(process) = Process::open(pid, PROCESS_QUERY_LIMITED_INFORMATION) else {
+            continue;
+        };
+        let mut counters: PROCESS_MEMORY_COUNTERS = unsafe { std::mem::zeroed() };
+        counters.cb = std::mem::size_of::<PROCESS_MEMORY_COUNTERS>() as u32;
+        // SAFETY: `counters` is a properly sized PROCESS_MEMORY_COUNTERS.
+        if unsafe { K32GetProcessMemoryInfo(process.0, &mut counters, counters.cb) } != 0 {
+            bytes += counters.WorkingSetSize as u64;
+        }
+    }
+    bytes as f64 / (1024.0 * 1024.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The pure helpers mirror proc.rs and keep its tests; the probe tests below
+    // run against the live machine, asserting only what any Windows box grants.
+
+    #[test]
+    fn subtree_walks_descendants_with_dedup_and_cycle_safety() {
+        let mut kids: HashMap<u32, Vec<u32>> = HashMap::new();
+        kids.insert(1, vec![2, 3]);
+        kids.insert(2, vec![4]);
+        kids.insert(3, vec![4]);
+        kids.insert(4, vec![1]);
+        kids.insert(999, vec![6]); // unrelated tree — must not be pulled in
+
+        let got = subtree(1, &kids);
+        assert_eq!(got, HashSet::from([1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn children_map_then_subtree_over_synthetic_procs() {
+        let procs: HashMap<u32, ProcEntry> = [
+            (1, 0),   // root
+            (2, 1),   // child of 1
+            (3, 1),   // child of 1
+            (4, 2),   // grandchild
+            (5, 4),   // great-grandchild
+            (6, 999), // unrelated subtree
+        ]
+        .into_iter()
+        .map(|(pid, ppid)| (pid, ProcEntry { ppid, jiffies: 0 }))
+        .collect();
+
+        let kids = children_map(&procs);
+        assert_eq!(subtree(1, &kids), HashSet::from([1, 2, 3, 4, 5]));
+    }
+
+    #[test]
+    fn ram_pct_math_rounds_and_guards_zero_total() {
+        assert_eq!(pct_string(1024.0, 16384.0), "6%");
+        assert_eq!(pct_string(250.0, 10000.0), "3%");
+        assert_eq!(pct_string(16384.0, 16384.0), "100%");
+        assert_eq!(pct_string(512.0, 0.0), "");
+    }
+
+    #[test]
+    fn scan_includes_our_own_process_with_cpu_ticks() {
+        let procs = scan_proc();
+        let me = procs
+            .get(&std::process::id())
+            .expect("our own pid is in the snapshot");
+        // Our own process is always openable, so its CPU counter is real.
+        assert!(me.jiffies > 0, "own cumulative CPU ticks read as zero");
+    }
+
+    #[test]
+    fn own_image_name_is_reported_and_vanished_pid_is_none() {
+        let name = process_image_name(std::process::id()).expect("own image name");
+        assert!(!name.is_empty());
+        assert_eq!(process_image_name(u32::MAX), None);
+    }
+
+    #[test]
+    fn machine_ram_total_is_positive() {
+        assert!(mem_total_mb() > 0.0);
+    }
+
+    #[test]
+    fn own_rss_is_positive() {
+        let pids = HashSet::from([std::process::id()]);
+        assert!(rss_mb(&pids) > 0.0);
+    }
+}

--- a/src/proc_windows.rs
+++ b/src/proc_windows.rs
@@ -43,11 +43,14 @@ pub fn clk_tck() -> u64 {
 ///
 /// `GetActiveProcessorCount(ALL_PROCESSOR_GROUPS)`, NOT
 /// `available_parallelism()`. The metric is a share of the WHOLE MACHINE, to
-/// match the Linux twin's `_SC_NPROCESSORS_ONLN`, and `available_parallelism`
-/// answers a different question: it honours the process affinity mask and job
-/// CPU limits, and counts only the caller's processor group — so on a box with
-/// more than 64 logical CPUs it saturates at 64 and every reported CPU% comes
-/// out inflated by the ratio.
+/// match the Linux twin's `_SC_NPROCESSORS_ONLN`. On Windows
+/// `available_parallelism` is `GetSystemInfo().dwNumberOfProcessors`, which is
+/// documented as the count for the CALLER'S PROCESSOR GROUP — so on a box with
+/// more than 64 logical CPUs it saturates at 64, halving the divisor and
+/// doubling every reported CPU%. (It is not affinity-aware either; std's own
+/// docs note it can overcount under a process affinity mask or job object
+/// limit. Neither function honours affinity, which is what keeps this in step
+/// with `_SC_NPROCESSORS_ONLN`.)
 pub fn nproc() -> u64 {
     // SAFETY: a pure query of a static system value.
     let n = unsafe { GetActiveProcessorCount(ALL_PROCESSOR_GROUPS) };
@@ -360,15 +363,16 @@ mod tests {
     fn nproc_counts_the_whole_machine() {
         let n = nproc();
         assert!(n >= 1, "nproc must never report zero");
-        // The machine-wide count can only be >= what this process is allowed to
-        // run on; `available_parallelism` is the affinity-limited, single-group
-        // answer this function deliberately does NOT use.
-        let affinity = std::thread::available_parallelism()
+        // Every processor group can only be >= the caller's single group, which
+        // is the answer `available_parallelism` gives and this function
+        // deliberately does NOT use. Equal on any box with <= 64 logical CPUs;
+        // strictly greater is exactly the case that used to double CPU%.
+        let one_group = std::thread::available_parallelism()
             .map(|n| n.get() as u64)
             .unwrap_or(1);
         assert!(
-            n >= affinity,
-            "machine-wide count {n} is below the affinity-limited {affinity}"
+            n >= one_group,
+            "all-groups count {n} is below the single-group {one_group}"
         );
     }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -9,8 +9,6 @@ use std::io::{self, IsTerminal, Write};
 
 use serde::Serialize;
 use serde_json::Number;
-use signal_hook::consts::{SIGINT, SIGTERM};
-use signal_hook::iterator::Signals;
 
 use crate::collect;
 use crate::config::Labels;
@@ -251,18 +249,11 @@ pub fn run_json(client: &mut Herdr) -> crate::Result<()> {
 
 /// `--interval`: live watch, redrawing every `interval_ms` (first frame quick).
 ///
-/// A background thread restores the cursor and exits on SIGINT/SIGTERM; the
-/// main loop hides the cursor, then clears + redraws each frame,
-/// widening the CPU window from the quick first frame to `interval_ms`.
+/// A SIGINT/SIGTERM hook (a console ctrl handler on Windows) restores the
+/// cursor and exits; the main loop hides the cursor, then clears + redraws each
+/// frame, widening the CPU window from the quick first frame to `interval_ms`.
 pub fn run_interval(client: &mut Herdr, labels: &Labels, interval_ms: u64) -> crate::Result<()> {
-    let mut signals = Signals::new([SIGINT, SIGTERM])?;
-    std::thread::spawn(move || {
-        if signals.forever().next().is_some() {
-            print!("\x1b[?25h"); // show cursor
-            let _ = io::stdout().flush();
-            std::process::exit(0);
-        }
-    });
+    install_quit_hook()?;
 
     let mut out = io::stdout();
     write!(out, "\x1b[?25l")?; // hide cursor
@@ -296,8 +287,46 @@ pub fn run_interval(client: &mut Herdr, labels: &Labels, interval_ms: u64) -> cr
     }
 }
 
+/// Show the cursor again and exit — the shared body of both quit hooks.
+fn restore_cursor_and_exit() -> ! {
+    print!("\x1b[?25h"); // show cursor
+    let _ = io::stdout().flush();
+    std::process::exit(0);
+}
+
+/// Restore the cursor on SIGINT/SIGTERM via a signal-hook thread.
+#[cfg(unix)]
+fn install_quit_hook() -> crate::Result<()> {
+    let mut signals = signal_hook::iterator::Signals::new([
+        signal_hook::consts::SIGINT,
+        signal_hook::consts::SIGTERM,
+    ])?;
+    std::thread::spawn(move || {
+        if signals.forever().next().is_some() {
+            restore_cursor_and_exit();
+        }
+    });
+    Ok(())
+}
+
+/// Restore the cursor on Ctrl+C / console close via a console ctrl handler
+/// (Windows delivers these on their own thread, so exiting from it is fine).
+#[cfg(windows)]
+fn install_quit_hook() -> crate::Result<()> {
+    use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
+    unsafe extern "system" fn on_ctrl(_ctrl_type: u32) -> i32 {
+        restore_cursor_and_exit();
+    }
+    // SAFETY: registering a handler with a 'static function pointer.
+    if unsafe { SetConsoleCtrlHandler(Some(on_ctrl), 1) } == 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok(())
+}
+
 /// Local wall-clock `HH:MM:SS` for the live-watch footer stamp (cosmetic — not
 /// part of any output contract).
+#[cfg(unix)]
 fn local_time_string() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     let secs = SystemTime::now()
@@ -308,6 +337,17 @@ fn local_time_string() -> String {
     let mut tm: libc::tm = unsafe { std::mem::zeroed() };
     unsafe { libc::localtime_r(&secs, &mut tm) };
     format!("{:02}:{:02}:{:02}", tm.tm_hour, tm.tm_min, tm.tm_sec)
+}
+
+/// Local wall-clock `HH:MM:SS` via `GetLocalTime` (already timezone-adjusted).
+#[cfg(windows)]
+fn local_time_string() -> String {
+    use windows_sys::Win32::Foundation::SYSTEMTIME;
+    use windows_sys::Win32::System::SystemInformation::GetLocalTime;
+    let mut st: SYSTEMTIME = unsafe { std::mem::zeroed() };
+    // SAFETY: `GetLocalTime` fills the caller-owned SYSTEMTIME.
+    unsafe { GetLocalTime(&mut st) };
+    format!("{:02}:{:02}:{:02}", st.wHour, st.wMinute, st.wSecond)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

Two changes, one per commit:

1. **Windows support** (`8913a8b`) — the plugin now runs on the herdr Windows beta alongside Linux.
2. **Plugin-pane guard** (`abeb8a2`) — the agents-panel pseudo-agent is never hosted on a pane owned by another plugin. This fixes a real conflict observed with herdr-sidebar (a second "agent" row appeared, with the usage text pinned to the sidebar pane), and applies to any plugin that opens panes.

## How

### Windows port

- `src/proc_windows.rs` — a twin of the `/proc` reader with the same public surface, selected via `#[cfg]` + `#[path]` in `main.rs`: process table from a Toolhelp32 snapshot (pid/ppid), cumulative CPU from `GetProcessTimes` (100 ns FILETIME ticks, so `clk_tck()` is 1e7 — the shared math in `collect::measure` is unchanged), RSS from `K32GetProcessMemoryInfo` working sets, machine total from `GlobalMemoryStatusEx`. Processes that cannot be opened still contribute their pid→ppid edge so subtree topology stays correct; they sample as zero, which is right for panes we own (a pane's subtree runs as the current user).
- `herdr.rs` — a platform `Stream` alias: the persistent `UnixStream` on unix; on Windows the herdr socket is the named pipe `\\.\pipe\<HERDR_SOCKET_PATH>` (the whole path is folded into the pipe name by interprocess' namespaced naming), which a read+write `File` can speak — the same pattern herdr-sidebar's `ipc.rs` uses.
- `daemon.rs` — platform-neutral liveness/identity via `proc::process_image_name` (replaces `kill(pid, 0)` + `/proc/<pid>/comm`), `proc::stop_process` (SIGTERM / `TerminateProcess`), detach via `setsid` on unix and `CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP` on Windows. The SIGINT/SIGTERM shutdown thread stays unix-only: on Windows `--disable` terminates the daemon outright, and the TTL'd statuses plus `--disable`'s sweep cover the cleanup.
- `render.rs` — quit hook via `SetConsoleCtrlHandler`, local time via `GetLocalTime`.
- `config.rs` — config home resolves to `%APPDATA%` on Windows (where the beta keeps `config.toml` and `herdr.sock`).
- `libc`/`signal-hook` become unix-only dependencies; `windows-sys` is Windows-only. Manifest `platforms` widened to `["linux", "windows"]`; CI runs an ubuntu+windows matrix.

### Plugin-pane guard

`session.snapshot` exposes each pane's metadata-token map, and plugin-owned panes stamp identity tokens on themselves (herdr-sidebar keeps `herdr-sidebar-explorer` / `herdr-sidebar-git` heartbeats, for example). `classify_panes` now treats an agent-less pane carrying tokens other than our own `usage` token as plugin-owned and keeps it out of the spare bucket. Two deliberate edges, both unit-tested:

- a pane carrying only our fall-through `usage` token stays a spare pane (otherwise the status would hop panes every cycle);
- the check only gates spares — an agent pane with foreign badge tokens (e.g. llmtrim's) stays an agent pane.

Measurement is unaffected: the `roots` loop covers every pane of the workspace regardless of classification, so plugin panes still count toward their space's CPU/RAM.

## Verification

- `cargo test` on Windows 11 (herdr 0.8.0-preview): 64 passed, 0 failed. `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
- Live against the Windows beta: `--json` returns real per-space data over the pipe; installed via `herdr plugin install`, `report` / `status-enable` invoked through herdr; with herdr-sidebar active, the usage row lands on a plain shell pane while the sidebar panes keep only their own tokens (verified in `herdr api snapshot`), in both agents-panel and sidebar modes.
- Existing Linux behavior untouched at the API level: the unix `proc.rs` is unchanged apart from hosting the two helpers `daemon.rs` now shares (`process_image_name`, `stop_process`); I have not run the test suite on a Linux box, but the CI matrix covers `ubuntu-latest`.

One operational note for Windows users is in the README: reinstalling over a running updater fails with a file lock — run `status-disable` first (the daemon holds the old exe open).
