### PR TITLE
Battery indicator, icon tiers, and macOS support (v1.6.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,3 @@ jobs:
 
       - name: Build release
         run: cargo build --release
-</content>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,26 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # All three are hard gates.
+  #
+  # Windows compiles and is live-verified against the herdr 0.8.0-preview beta
+  # (Win32 process sampling + named-pipe transport), so a Windows regression
+  # must fail the build like any other.
+  #
+  # macOS compiles today because the socket client is a UnixStream and
+  # signal-hook is a POSIX dependency, so Darwin needs nothing special to build.
+  # It is still functionally degraded until a Darwin process backend lands: the
+  # module tree routes every unix target at the `/proc` reader, which does not
+  # exist on macOS, so CPU/RAM read zero there. The tests that run are the
+  # platform-neutral ones, and they are worth gating on — they catch Darwin
+  # build breakage the moment it appears.
   build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -35,3 +50,4 @@ jobs:
 
       - name: Build release
         run: cargo build --release
+</content>

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 *.log
 /target
 /tasks
+worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "space-usage"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "libc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "space-usage"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 description = "CPU and RAM usage per herdr space, grouped under the branch name."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -200,5 +200,3 @@ build step, so run `cargo build --release` first — the linked commands invoke
 ## License
 
 MIT — see [LICENSE](LICENSE).
-</content>
-</invoke>

--- a/README.md
+++ b/README.md
@@ -8,15 +8,17 @@ a glance which space is eating your machine.
 ```
 ● web-app
     main
-    cpu 26% · ram 8%          ← spaces card (sidebar mode, patched herdr)
+    cpu ░26% · ram ░8% · bat ▓74%+   ← spaces card (sidebar mode)
 
 ⚡ web-app
-    idle · usage · cpu 26% · ram 8%   ← agents panel (default mode, stock herdr)
+    idle · usage · cpu ░26% · ram ░8%   ← agents panel (default mode)
 ```
 
 - Per-space CPU% and RAM%, both a share of the **whole machine** (0–100%, so a
   busy space reads e.g. `cpu 4%` — not a per-core figure that can exceed 100%),
   refreshed every 5s
+- **Battery** next to them, with a charge-level gauge — and **hidden entirely on
+  a machine that has none**, so desktops and servers see no empty cell
 - **Worktree-aware**: workspaces opened as worktree children are folded into
   their parent space's total
 - All-space totals in your terminal's window title: `spaces · cpu 39% · ram 8%`
@@ -24,7 +26,7 @@ a glance which space is eating your machine.
 - A small static Rust binary (~2–5 MB resident) that talks to herdr over its
   unix socket (a named pipe on Windows) — no per-sample subprocess spawns, no
   Node runtime
-- Runs on **Linux and Windows** (herdr Windows beta)
+- Runs on **Linux, macOS, and Windows** (herdr Windows beta)
 
 ## Install
 
@@ -32,10 +34,18 @@ a glance which space is eating your machine.
 herdr plugin install ezcorp-org/herdr-pc-ram-and-cpu-usage-overlay
 ```
 
-Requirements: Linux or Windows, and the **Rust toolchain** (`cargo`) on the box
-hosting the herdr server — herdr compiles the plugin at install time via
+Requirements: Linux, macOS, or Windows, and the **Rust toolchain** (`cargo`) on
+the box hosting the herdr server — herdr compiles the plugin at install time via
 `cargo build --release`. Plugins run on the machine hosting the herdr server, so
 remote setups need these on the server box only. `node` is no longer required.
+
+Each platform reads processes its own way, chosen at compile time:
+
+| Platform | Process sampling | Battery |
+|---|---|---|
+| Linux | `/proc` | `/sys/class/power_supply` |
+| macOS | `libproc` (`proc_listallpids`, `proc_pidinfo`) | `pmset -g batt` |
+| Windows | Toolhelp32 + `GetProcessTimes` | `GetSystemPowerStatus` |
 
 On Windows the sampling uses the Win32 process APIs instead of `/proc`, and the
 herdr socket is reached through its named pipe; both are handled automatically.
@@ -58,6 +68,7 @@ Other entrypoints:
 herdr plugin pane open --plugin ez-corp.space-usage --entrypoint dashboard  # live dashboard
 herdr plugin action invoke report --plugin ez-corp.space-usage             # one-shot snapshot
 ./target/release/space-usage --json                                        # machine-readable
+./target/release/space-usage --icons                                       # preview icon tiers
 ```
 
 Status **text** carries a TTL and self-clears if the updater dies. In
@@ -89,6 +100,8 @@ mode = "agents-panel"       # default — works on stock herdr
 # mode = "sidebar"          # for herdr builds with the sidebar patch (below)
 interval_seconds = 5        # 1..28800; statuses get a TTL of three intervals
 window_title_totals = true
+battery = true              # show the battery cell when the machine has one
+icons = "auto"              # auto | text | unicode | nerdfont | emoji
 ```
 
 - **agents-panel** (default): each space gets its own entry in the sidebar agents
@@ -121,12 +134,65 @@ Built-in `branch` / `git_status` (ahead/behind) tokens are native, so the old
 space-usage-line and git-dirty herdr patches are retired. Requires herdr ≥ 0.7.5
 (the `tokens` metadata API); older builds need plugin v1.0.x.
 
-## Labels
+## Battery
 
-The `cpu`/`ram` tokens are read from herdr's own `config.toml` `[ui]`
-(`cpu_label` / `ram_label`, default `cpu`/`ram`) — set them to nerd-font icons to
-taste. On a patched build this also matches the sidebar's system-usage header,
-which reads the same two keys. Restart the updater to pick up a change.
+The battery cell sits next to cpu and ram, and **disappears completely on a
+machine that has no battery** — a desktop, a server, or a VM shows nothing
+rather than a fabricated `0%`.
+
+```
+cpu ░26% · ram ░8% · bat ▓74%+      74% and charging
+cpu ░26% · ram ░8% · bat ▒52%       52% on battery
+cpu ░26% · ram ░8%                  no battery in this machine
+```
+
+A trailing `+` means charging; `=` means on power but holding (full, or capped
+by a vendor charge limit). Turn the cell off with `battery = false`, which also
+skips the read entirely — no sysfs walk, no `pmset` process.
+
+Two details worth knowing:
+
+- On Linux, peripherals register as batteries too. A wireless mouse appears in
+  `/sys/class/power_supply` as `type=Battery` with `scope=Device`; those are
+  filtered out, so your mouse never gets reported as the machine's battery.
+- Plugins run on the machine hosting the **herdr server**. Attach from a laptop
+  to a remote server and the battery shown is the *server's* — usually none.
+  That is consistent with cpu and ram, which are also the server's.
+
+Because herdr's sidebar has no machine-wide row, one battery reading is drawn
+once per space card. With three spaces open you will see it three times. The
+full-width `--once` report avoids this by putting it on the total line only.
+
+## Icons and labels
+
+`icons` picks the glyph vocabulary. Run **`space-usage --icons`** to see all four
+drawn in your own terminal before choosing — whether a Nerd Font is installed,
+and whether your terminal draws emoji at one column or two, is something only you
+can see.
+
+| tier | renders | needs |
+|---|---|---|
+| `text` | `cpu 26% · ram 8% · bat 74%` | nothing |
+| `unicode` | `cpu ░26% · ram ░8% · bat ▓74%` | nothing |
+| `nerdfont` | ` 26% ·  8% ·  74%` | a Nerd Font |
+| `emoji` | `💻26% · 🧠8% · 🔋74%` | a colour emoji font |
+
+`auto` (the default) picks `unicode` on a UTF-8 locale and `text` otherwise.
+
+The `unicode` tier is a **level gauge**, not a pictogram: `░` below 34%, `▒`
+below 67%, `▓` below 90%, `█` above. That choice is deliberate. There is no
+pictogram for "CPU" or "battery" that renders without installing a font — the
+battery emoji `U+1F50B` is absent from both DejaVu Sans Mono and Liberation Mono
+(the default Linux mono faces), and Nerd Font glyphs live in the Private Use
+Area. Every glyph the safe tiers emit was checked with `fc-list :charset=<cp>`
+against both faces and is present in both; a test asserts they stay inside the
+BMP, outside the Private Use Area, and on that measured list, so the "no font
+install" promise cannot rot.
+
+The words themselves come from herdr's own `config.toml` `[ui]` — `cpu_label`,
+`ram_label`, and `battery_label` (default `cpu`/`ram`/`bat`). An explicit label
+always wins over the tier's own wording, so you can still set them to whatever
+you like. Restart the updater to pick up a change.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -233,20 +233,50 @@ honours them too — and **an explicit label replaces the tier's glyph rather th
 stacking with it**, so you never get the icon drawn twice:
 
 ```toml
-# in herdr's own config.toml
+# in herdr's own config.toml — drives BOTH the header and these rows
 [ui]
 cpu_label = ""
 ram_label = ""
-battery_label = ""     # plugin-only; the header has no battery
 ```
 
-`space-usage --icons` prints exactly this block for whichever tier you are
-previewing, so you can copy it straight across. Pair it with `icons = "text"` in
-the plugin config — with the labels doing the naming, the tier has nothing left
-to add.
+```toml
+# in the plugin's config.toml — battery only
+battery_label = ""
+icons = "text"          # the labels are doing the naming now
+```
 
-Defaults are `cpu` / `ram` / `bat` when herdr names nothing. Restart the updater
-to pick up a change.
+`space-usage --icons` prints the `[ui]` block for whichever tier you are
+previewing, so you can copy it straight across.
+
+**Why battery is in the other file:** herdr has no battery of its own to label,
+so `battery_label` is not a key it knows. Putting it in herdr's `[ui]` makes
+every `herdr server reload-config` report
+`unknown config key ui.battery_label; ignoring key`. Nothing outside this plugin
+renders a battery, so there is no second surface to keep in step. `cpu_label`
+and `ram_label` live in herdr's config precisely because the header does share
+them.
+
+**Applying a change.** The updater re-reads both files every refresh, so the
+rows follow within one interval — no `status-toggle` needed. herdr's header
+picks up its own config on `herdr server reload-config`. So:
+
+```sh
+herdr server reload-config     # header updates; rows follow on the next refresh
+```
+
+Watch out for empty values. herdr ships these keys commented out with **blank**
+quotes and a note naming the glyph to paste:
+
+```toml
+# cpu_label = ""   #  nf-oct-cpu
+```
+
+Uncommenting that without pasting a glyph in leaves an empty label, which reads
+as *unset* — you get the tier's own naming back, not a blank. That is
+deliberate: honouring the blank literally would strip the naming off every row
+and leave bare percentages with no clue why.
+
+Defaults are `cpu` / `ram` / `bat` when nothing names them.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -220,10 +220,33 @@ against both faces and is present in both; a test asserts they stay inside the
 BMP, outside the Private Use Area, and on that measured list, so the "no font
 install" promise cannot rot.
 
-The words themselves come from herdr's own `config.toml` `[ui]` — `cpu_label`,
-`ram_label`, and `battery_label` (default `cpu`/`ram`/`bat`). An explicit label
-always wins over the tier's own wording, so you can still set them to whatever
-you like. Restart the updater to pick up a change.
+### One setting for both the header and these rows
+
+On a patched build the sidebar has a **whole-machine system-usage header** as
+well as these per-space rows, and the header is herdr's own — it renders from
+`cpu_label` / `ram_label` in herdr's `config.toml`. Setting only the plugin's
+`icons` changes the rows and leaves the header spelling `cpu` in words directly
+above a row of glyphs.
+
+Those two keys are the single point that changes both, because this plugin
+honours them too — and **an explicit label replaces the tier's glyph rather than
+stacking with it**, so you never get the icon drawn twice:
+
+```toml
+# in herdr's own config.toml
+[ui]
+cpu_label = ""
+ram_label = ""
+battery_label = ""     # plugin-only; the header has no battery
+```
+
+`space-usage --icons` prints exactly this block for whichever tier you are
+previewing, so you can copy it straight across. Pair it with `icons = "text"` in
+the plugin config — with the labels doing the naming, the tier has nothing left
+to add.
+
+Defaults are `cpu` / `ram` / `bat` when herdr names nothing. Restart the updater
+to pick up a change.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Other entrypoints:
 ```sh
 herdr plugin pane open --plugin ez-corp.space-usage --entrypoint dashboard  # live dashboard
 herdr plugin action invoke report --plugin ez-corp.space-usage             # one-shot snapshot
+herdr plugin action invoke icons --plugin ez-corp.space-usage              # preview icon tiers
 ./target/release/space-usage --json                                        # machine-readable
-./target/release/space-usage --icons                                       # preview icon tiers
 ```
 
 Status **text** carries a TTL and self-clears if the updater dies. In
@@ -165,10 +165,10 @@ full-width `--once` report avoids this by putting it on the total line only.
 
 ## Icons and labels
 
-`icons` picks the glyph vocabulary. Run **`space-usage --icons`** to see all four
-drawn in your own terminal before choosing — whether a Nerd Font is installed,
-and whether your terminal draws emoji at one column or two, is something only you
-can see.
+`icons` picks the glyph vocabulary. Run the **Preview icon tiers** action (or
+`space-usage --icons`) to see all four drawn in your own terminal before
+choosing — whether a Nerd Font is installed, and whether your terminal draws
+emoji at one column or two, is something only you can see.
 
 | tier | renders | needs |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ a glance which space is eating your machine.
 ```
 ● web-app
     main
-    cpu ░26% · ram ░8% · bat ▓74%+   ← spaces card (sidebar mode)
+    cpu 26% · ram 8% · bat 74%+     ← spaces card (sidebar mode)
 
 ⚡ web-app
-    idle · usage · cpu ░26% · ram ░8%   ← agents panel (default mode)
+    idle · usage · cpu 26% · ram 8%   ← agents panel (default mode)
 ```
+
+With a Nerd Font installed it detects that and uses icons instead —
+` 26% ·  8% ·  74%+`. See [Icons](#icons-and-labels).
 
 - Per-space CPU% and RAM%, both a share of the **whole machine** (0–100%, so a
   busy space reads e.g. `cpu 4%` — not a per-core figure that can exceed 100%),
@@ -173,18 +176,46 @@ emoji at one column or two, is something only you can see.
 | tier | renders | needs |
 |---|---|---|
 | `text` | `cpu 26% · ram 8% · bat 74%` | nothing |
-| `unicode` | `cpu ░26% · ram ░8% · bat ▓74%` | nothing |
+| `unicode` | `cpu ░26% · ram ░8% · bat ▓74%` | nothing (opt-in) |
 | `nerdfont` | ` 26% ·  8% ·  74%` | a Nerd Font |
 | `emoji` | `💻26% · 🧠8% · 🔋74%` | a colour emoji font |
 
-`auto` (the default) picks `unicode` on a UTF-8 locale and `text` otherwise.
+### What `auto` does
 
-The `unicode` tier is a **level gauge**, not a pictogram: `░` below 34%, `▒`
-below 67%, `▓` below 90%, `█` above. That choice is deliberate. There is no
-pictogram for "CPU" or "battery" that renders without installing a font — the
-battery emoji `U+1F50B` is absent from both DejaVu Sans Mono and Liberation Mono
-(the default Linux mono faces), and Nerd Font glyphs live in the Private Use
-Area. Every glyph the safe tiers emit was checked with `fc-list :charset=<cp>`
+`auto` (the default) tries to detect whether this machine can draw icons:
+
+1. If the locale is not UTF-8 → `text`. A terminal that cannot carry UTF-8
+   cannot carry a Nerd Font glyph either, and this costs two `getenv`s.
+2. Otherwise it asks fontconfig (`fc-list :charset=f4bc`) whether any installed
+   font carries a Nerd Font glyph. Found → `nerdfont`. Not found → `text`.
+
+The probe runs **once per process** and is cached; the updater never re-forks it.
+
+Two honest limits:
+
+- **It detects "a Nerd Font is installed", not "your terminal uses one".** herdr
+  draws into whatever terminal emulator you launched it from, and that font
+  lives in the emulator's own config, which no plugin can read. The updater
+  daemon runs detached with null stdio, so it has no terminal to interrogate
+  even in principle. If you have a Nerd Font on disk but your terminal is set to
+  something else, `auto` will guess wrong — set `icons` explicitly.
+- **fontconfig is a Linux convention.** macOS and Windows generally have no
+  `fc-list`, so `auto` yields `text` there. Run the preview and pick a tier.
+
+The fallback is always `text`, never a guess: an unreadable sidebar is strictly
+worse than plain words.
+
+`auto` never selects `unicode`. Those glyphs are *present* in the stock faces —
+that was measured — but `░` and `▒` are dither patterns, and at terminal sizes
+they render as an indistinct blob rather than a light shade. Present and legible
+are different properties and only the first can be measured from here, so the
+gauge is opt-in. If you want it: `░` below 34%, `▒` below 67%, `▓` below 90%,
+`█` above.
+
+There is no pictogram for "CPU" or "battery" that renders without installing a
+font: the battery emoji `U+1F50B` is absent from both DejaVu Sans Mono and
+Liberation Mono, and Nerd Font glyphs live in the Private Use Area. Every glyph
+the `text` and `unicode` tiers emit was checked with `fc-list :charset=<cp>`
 against both faces and is present in both; a test asserts they stay inside the
 BMP, outside the Private Use Area, and on that measured list, so the "no font
 install" promise cannot rot.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -13,7 +13,7 @@
 
 id = "ez-corp.space-usage"
 name = "PC RAM & CPU Usage Overlay"
-version = "1.5.0"
+version = "1.6.0"
 # Oldest herdr with every API this plugin calls: `session.snapshot`, the `tokens`
 # metadata API on `pane.report_metadata` / `workspace.report_metadata`, and
 # `pane.process_info` — all 0.7.5. Diffing the two bundled API schemas
@@ -21,7 +21,7 @@ version = "1.5.0"
 # used here, so this stays put; developed and tested against 0.8.0.
 min_herdr_version = "0.7.5"
 description = "CPU and RAM usage per space, grouped under the branch name."
-platforms = ["linux", "windows"]
+platforms = ["linux", "macos", "windows"]
 
 # Commands are argv arrays (no shell) and run with the plugin dir as cwd,
 # per https://herdr.dev/docs/plugins/#trust-and-security
@@ -31,7 +31,7 @@ platforms = ["linux", "windows"]
 # what every pane/action command below invokes (relative to the plugin root).
 [[build]]
 command = ["cargo", "build", "--release"]
-platforms = ["linux", "windows"]
+platforms = ["linux", "macos", "windows"]
 
 # Restart recovery. herdr runs startup hooks on both a fresh server start and a
 # live handoff (`herdr update --handoff`), so this fires whenever herdr comes
@@ -42,7 +42,7 @@ platforms = ["linux", "windows"]
 # the sidebar stays blank until someone re-invokes status-enable by hand.
 [[startup]]
 command = ["./target/release/space-usage", "--restore"]
-platforms = ["linux", "windows"]
+platforms = ["linux", "macos", "windows"]
 
 # Live, self-refreshing dashboard. Opened as a temporary zoomed overlay pane.
 [[panes]]

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -58,6 +58,16 @@ title = "Space usage report"
 contexts = ["workspace"]
 command = ["./target/release/space-usage", "--once"]
 
+# Draws the cpu/ram/battery row in all four icon tiers so the user can pick one
+# by eye. Whether a Nerd Font is installed, and whether the terminal draws emoji
+# at one column or two, is visible only to the person looking at the screen —
+# so the plugin shows the options rather than guessing. Needs no herdr
+# connection, so it still works with the server down.
+[[actions]]
+id = "icons"
+title = "Preview icon tiers"
+command = ["./target/release/space-usage", "--icons"]
+
 # Sidebar status updater: a background daemon that pushes each space's usage
 # as display-only metadata on a spare shell pane; the locally patched herdr
 # renders it as a third row in the sidebar spaces card. Statuses carry a TTL,

--- a/src/battery.rs
+++ b/src/battery.rs
@@ -1,0 +1,1098 @@
+//! Battery presence and charge state, one backend per platform.
+//!
+//! [`read`] answers a single question for the renderer: *what should the battery
+//! cell show, if anything?* `None` is a first-class answer — a desktop, a
+//! server, or a VM has no battery, and the metric has to disappear rather than
+//! render a fabricated 0%.
+//!
+//! Every backend is split in two: an impure half that touches the host (a sysfs
+//! walk, a `pmset` child process, a Win32 call) and a pure half that turns the
+//! text or the raw fields it produced into a [`Battery`]. Only the impure halves
+//! carry `#[cfg]` — the parsers compile, and are unit-tested, on every target,
+//! so a mistake in the macOS parser is caught by a Linux test run.
+
+/// Charge state as reported by the host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum State {
+    Charging,
+    Discharging,
+    Full,
+    NotCharging,
+    Unknown,
+}
+
+/// A machine-wide battery reading.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Battery {
+    /// Charge percentage, 0..=100.
+    pub percent: f64,
+    pub state: State,
+}
+
+/// Current battery reading, or `None` when this host has no battery.
+///
+/// Backends: `/sys/class/power_supply` on Linux, `pmset -g batt` on macOS,
+/// `GetSystemPowerStatus` on Windows, and "no battery" everywhere else. A
+/// backend that cannot answer — missing files, a failed call, a percentage the
+/// OS itself flags as unknown — also returns `None`: hiding the cell is always
+/// better than showing a number we invented.
+pub fn read() -> Option<Battery> {
+    host_read()
+}
+
+/// Linux: walk the `power_supply` class.
+#[cfg(target_os = "linux")]
+fn host_read() -> Option<Battery> {
+    sysfs::read_from_root(std::path::Path::new(sysfs::ROOT))
+}
+
+/// macOS: ask `pmset`.
+#[cfg(target_os = "macos")]
+fn host_read() -> Option<Battery> {
+    pmset::probe()
+}
+
+/// Windows: ask `kernel32`.
+#[cfg(windows)]
+fn host_read() -> Option<Battery> {
+    power_status::probe()
+}
+
+/// Every other target (the BSDs, illumos, ..): no battery API we speak, so the
+/// caller hides the metric exactly as it would on a desktop.
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+fn host_read() -> Option<Battery> {
+    None
+}
+
+/// The single gate every backend pushes its percentage through: pin it into the
+/// 0..=100 the UI can render, or reject it outright.
+///
+/// Hosts do lie. A freshly calibrated pack reports `energy_now` above
+/// `energy_full` (>100%), a dying one can report a negative charge, and a
+/// division by a zeroed capacity yields NaN — which would otherwise sail
+/// through `clamp` unchanged and render as `NaN%`. `None` means "nothing worth
+/// rendering", which the callers already handle.
+fn checked_percent(percent: f64) -> Option<f64> {
+    percent.is_finite().then(|| percent.clamp(0.0, 100.0))
+}
+
+// ---- Linux: /sys/class/power_supply -----------------------------------------
+
+/// Linux battery backend: the `power_supply` class in sysfs.
+///
+/// Compiled on every target — only [`read_from_root`](sysfs::read_from_root)'s
+/// caller is Linux-gated — so the filtering, parsing, and aggregation stay under
+/// test everywhere. Off Linux nothing but those tests reaches the module, hence
+/// the `dead_code` waiver.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+mod sysfs {
+    use super::{checked_percent, Battery, State};
+    use std::path::Path;
+
+    /// The class directory every power supply registers under — batteries, AC
+    /// adapters, and USB peripherals alike.
+    pub const ROOT: &str = "/sys/class/power_supply";
+
+    /// One `power_supply` entry that passed the battery filter.
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    pub struct Supply {
+        /// Charge percentage, already clamped to 0..=100.
+        pub percent: f64,
+        pub state: State,
+        /// `(now, full)` from the `energy_*` pair, else the `charge_*` pair,
+        /// when both sides are readable and `full` is positive. Kept so a
+        /// multi-pack host can aggregate by real capacity instead of averaging
+        /// the percentages of differently sized packs.
+        pub charge: Option<(f64, f64)>,
+    }
+
+    /// Every battery under `root`, folded into one reading.
+    ///
+    /// `root` is a parameter rather than the [`ROOT`] constant so the tests can
+    /// point the real walk at a fixture tree. A missing or unreadable root — a
+    /// container, a kernel built without the `power_supply` class — is simply
+    /// "no battery".
+    pub fn read_from_root(root: &Path) -> Option<Battery> {
+        let mut dirs: Vec<_> = std::fs::read_dir(root)
+            .ok()?
+            .flatten()
+            .map(|entry| entry.path())
+            .collect();
+        // `readdir` order is arbitrary; sorting makes `BAT0` decide before
+        // `BAT1` so a two-pack host reports the same state on every scan.
+        dirs.sort();
+        let supplies: Vec<Supply> = dirs.iter().filter_map(|dir| read_supply(dir)).collect();
+        aggregate(&supplies)
+    }
+
+    /// Read one `/sys/class/power_supply/<name>` directory, or `None` when it is
+    /// not a system battery, or reports nothing we can turn into a percentage.
+    ///
+    /// The `scope` check is load-bearing: a wireless mouse or keyboard registers
+    /// here as `type=Battery` with `scope=Device`, and announcing a mouse at 40%
+    /// as "the machine's battery" is worse than showing nothing at all.
+    pub fn read_supply(dir: &Path) -> Option<Supply> {
+        if read_attr(dir, "type")? != "Battery" {
+            return None; // AC adapter (`Mains`), USB PD source, ..
+        }
+        if read_attr(dir, "scope").as_deref() == Some("Device") {
+            return None; // a peripheral's battery, not the machine's
+        }
+        // `energy_*` (µWh) is what a laptop with a smart battery exports; the
+        // older `charge_*` (µAh) pair is the fallback. The ratio is
+        // dimensionless either way, so the units never need converting.
+        let charge = read_pair(dir, "energy_now", "energy_full")
+            .or_else(|| read_pair(dir, "charge_now", "charge_full"));
+        // `capacity` is the kernel's own already-computed percentage and is
+        // preferred: on some packs it is smoothed or vendor-corrected, whereas
+        // the raw pair is not.
+        let percent = read_number(dir, "capacity")
+            .or_else(|| charge.and_then(|(now, full)| ratio_percent(now, full)))?;
+        Some(Supply {
+            percent: checked_percent(percent)?,
+            state: parse_state(read_attr(dir, "status").as_deref().unwrap_or_default()),
+            charge,
+        })
+    }
+
+    /// Fold every battery on the host into the one reading the UI shows.
+    ///
+    /// Percentage: one pack keeps its own figure, which already honours the
+    /// `capacity`-first preference [`read_supply`] applied. Past that, when
+    /// *every* pack reports a `(now, full)` pair the totals are summed — the
+    /// only correct answer for unequal packs, since a 90% 20 Wh pack beside a
+    /// 10% 80 Wh pack is 26%, not 50%. Otherwise the percentages are averaged,
+    /// which is all the data allows.
+    ///
+    /// State: charging wins, because any pack drawing power means the machine is
+    /// charging; then discharging, so a full pack beside a draining one does not
+    /// read as "Full". With no signal either way the first pack decides (the
+    /// walk sorts by name, so that is `BAT0`).
+    pub fn aggregate(supplies: &[Supply]) -> Option<Battery> {
+        let first = supplies.first()?;
+        let percent = match supplies {
+            [only] => only.percent,
+            many => summed_percent(many).unwrap_or_else(|| average_percent(many)),
+        };
+        let state = if supplies.iter().any(|s| s.state == State::Charging) {
+            State::Charging
+        } else if supplies.iter().any(|s| s.state == State::Discharging) {
+            State::Discharging
+        } else {
+            first.state
+        };
+        Some(Battery {
+            percent: checked_percent(percent)?,
+            state,
+        })
+    }
+
+    /// Map the kernel's `status` attribute onto a [`State`].
+    ///
+    /// These four spellings plus `Unknown` are the complete
+    /// `POWER_SUPPLY_STATUS_*` set; anything else — including a missing file,
+    /// which arrives here as `""` — is [`State::Unknown`] rather than a guess.
+    pub fn parse_state(status: &str) -> State {
+        match status {
+            "Charging" => State::Charging,
+            "Discharging" => State::Discharging,
+            "Full" => State::Full,
+            "Not charging" => State::NotCharging,
+            _ => State::Unknown,
+        }
+    }
+
+    /// Percentage of the summed capacity, or `None` when any pack is missing its
+    /// `(now, full)` pair — mixing a real capacity with a bare percentage would
+    /// weight the packs wrong, so the caller falls back to averaging instead.
+    fn summed_percent(supplies: &[Supply]) -> Option<f64> {
+        let mut now = 0.0;
+        let mut full = 0.0;
+        for supply in supplies {
+            let (pack_now, pack_full) = supply.charge?;
+            now += pack_now;
+            full += pack_full;
+        }
+        ratio_percent(now, full)
+    }
+
+    /// Mean of the per-pack percentages. Never called with an empty slice —
+    /// [`aggregate`] returns early — so the division is safe.
+    fn average_percent(supplies: &[Supply]) -> f64 {
+        supplies.iter().map(|s| s.percent).sum::<f64>() / supplies.len() as f64
+    }
+
+    /// `now / full` as a percentage, or `None` when `full` cannot scale it.
+    fn ratio_percent(now: f64, full: f64) -> Option<f64> {
+        (full > 0.0).then(|| 100.0 * now / full)
+    }
+
+    /// `(now, full)` when both files parse and `full` is positive — a zero or
+    /// absent `full` makes the ratio meaningless.
+    fn read_pair(dir: &Path, now: &str, full: &str) -> Option<(f64, f64)> {
+        let now = read_number(dir, now)?;
+        let full = read_number(dir, full)?;
+        (full > 0.0).then_some((now, full))
+    }
+
+    /// Trimmed contents of `<dir>/<name>`, or `None` when the file is missing,
+    /// unreadable, or blank. Sysfs attributes always carry a trailing newline,
+    /// so the trim is not optional.
+    fn read_attr(dir: &Path, name: &str) -> Option<String> {
+        let text = std::fs::read_to_string(dir.join(name)).ok()?;
+        let trimmed = text.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    }
+
+    /// `<dir>/<name>` parsed as a *finite* number. `nan` and `inf` both parse
+    /// happily as `f64`, and one poisoned pack would otherwise NaN out the sum
+    /// for every other pack on the host — so they are rejected at the source.
+    fn read_number(dir: &Path, name: &str) -> Option<f64> {
+        read_attr(dir, name)?
+            .parse::<f64>()
+            .ok()
+            .filter(|n| n.is_finite())
+    }
+}
+
+// ---- macOS: `pmset -g batt` -------------------------------------------------
+
+/// macOS battery backend: the text `pmset -g batt` prints.
+///
+/// A text parse beats IOKit here. The IOKit route costs a CoreFoundation FFI
+/// surface — and the `unsafe` that comes with it — to fetch a value we refresh
+/// every few seconds, while `pmset`'s output shape has been stable for over a
+/// decade and its parser is testable on any host, including this Linux CI box.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+mod pmset {
+    use super::{checked_percent, Battery, State};
+
+    /// Ask `pmset` for the current reading, or `None` on a Mac with no battery.
+    ///
+    /// The *no battery* answer is latched in a `OnceLock`: a Mac mini will never
+    /// grow a battery mid-session, and without the latch every refresh tick
+    /// would fork a `pmset` child just to be told the same thing again. A
+    /// present battery is deliberately *not* cached — the percentage is the
+    /// whole point of asking.
+    ///
+    /// Only a command that actually ran can latch. A spawn failure (fork
+    /// refused under memory pressure) stays retryable.
+    #[cfg(target_os = "macos")]
+    pub fn probe() -> Option<Battery> {
+        use std::sync::OnceLock;
+
+        static NO_BATTERY: OnceLock<()> = OnceLock::new();
+        if NO_BATTERY.get().is_some() {
+            return None;
+        }
+        let output = std::process::Command::new("pmset")
+            .args(["-g", "batt"])
+            .output()
+            .ok()?;
+        let reading = parse(&String::from_utf8_lossy(&output.stdout));
+        if reading.is_none() {
+            let _ = NO_BATTERY.set(());
+        }
+        reading
+    }
+
+    /// Pull the first present internal battery out of `pmset -g batt` stdout.
+    ///
+    /// Real output on a laptop is two lines (`<TAB>` stands in for the literal
+    /// tab `pmset` prints, which a doc comment cannot carry):
+    ///
+    /// ```text
+    /// Now drawing from 'AC Power'
+    ///  -InternalBattery-0 (id=12345)<TAB>97%; charging; 1:23 remaining present: true
+    /// ```
+    ///
+    /// A desktop Mac prints only the `Now drawing from` line — no
+    /// `-InternalBattery` entry at all — which is exactly the `None` we want.
+    pub fn parse(stdout: &str) -> Option<Battery> {
+        stdout
+            .lines()
+            .map(str::trim)
+            .filter(|line| line.starts_with("-InternalBattery"))
+            .find_map(parse_line)
+    }
+
+    /// Parse one `-InternalBattery-N` line.
+    ///
+    /// The line is `;`-separated: `<id> <percent>%`, then ` <state>`, then
+    /// ` <time> remaining present: <bool>`. A pack the SMC reports as absent
+    /// (`present: false`) is skipped, and so is a line carrying no percentage —
+    /// there would be no number to render.
+    fn parse_line(line: &str) -> Option<Battery> {
+        if line.contains("present: false") {
+            return None;
+        }
+        let mut fields = line.split(';');
+        // The id field is `-InternalBattery-0 (id=12345)\t97%`, so the percent
+        // is the one whitespace-delimited token ending in `%`.
+        let percent = fields
+            .next()?
+            .split_whitespace()
+            .find_map(|token| token.strip_suffix('%')?.parse::<f64>().ok())?;
+        Some(Battery {
+            percent: checked_percent(percent)?,
+            state: parse_state(fields.next().unwrap_or_default()),
+        })
+    }
+
+    /// Map `pmset`'s state word onto a [`State`]. Matching is case-insensitive
+    /// because the same field is printed as `AC attached` but as `charging`.
+    fn parse_state(field: &str) -> State {
+        match field.trim().to_ascii_lowercase().as_str() {
+            "charging" => State::Charging,
+            "discharging" => State::Discharging,
+            // `finishing charge` is the trickle at the top of a charge cycle;
+            // the UI shows it as full rather than inventing a sixth state.
+            "charged" | "finishing charge" => State::Full,
+            // On AC with the charge deliberately held back (battery health
+            // management): plugged in, but not moving.
+            "ac attached" => State::NotCharging,
+            _ => State::Unknown,
+        }
+    }
+}
+
+// ---- Windows: GetSystemPowerStatus ------------------------------------------
+
+/// Windows battery backend: `kernel32!GetSystemPowerStatus`.
+///
+/// Hand-declared rather than pulled from `windows-sys`: one struct and one
+/// function is less surface than another feature flag, and keeping the binding
+/// local lets [`map`](power_status::map) — the half with the actual logic — take
+/// plain `u8`s, so it is unit-tested on Linux and macOS too.
+#[cfg_attr(not(windows), allow(dead_code))]
+mod power_status {
+    use super::{checked_percent, Battery, State};
+
+    /// `BatteryFlag` bit meaning the machine has no battery at all.
+    const NO_SYSTEM_BATTERY: u8 = 128;
+    /// `BatteryFlag` sentinel for "status unknown".
+    const FLAG_UNKNOWN: u8 = 255;
+    /// `BatteryLifePercent` sentinel for "percentage unknown".
+    const PERCENT_UNKNOWN: u8 = 255;
+    /// `ACLineStatus`: running on battery.
+    const AC_OFFLINE: u8 = 0;
+    /// `ACLineStatus`: plugged in.
+    const AC_ONLINE: u8 = 1;
+
+    /// Turn the three `SYSTEM_POWER_STATUS` fields we care about into a reading.
+    ///
+    /// Order matters: `255` (unknown) has the `128` no-battery bit set, so the
+    /// unknown sentinel must be ruled out *before* the bit test. Testing the bit
+    /// first would report every laptop that momentarily cannot read its battery
+    /// as a desktop, and the metric would blink out.
+    pub fn map(ac_line: u8, battery_flag: u8, life_percent: u8) -> Option<Battery> {
+        let flag_unknown = battery_flag == FLAG_UNKNOWN;
+        if !flag_unknown && battery_flag & NO_SYSTEM_BATTERY != 0 {
+            return None; // desktop or server — hide the metric
+        }
+        if life_percent == PERCENT_UNKNOWN {
+            return None; // no number to render, so render nothing
+        }
+        let percent = checked_percent(f64::from(life_percent))?;
+        let state = match ac_line {
+            // The percentage can still be trustworthy when the flag is not, so
+            // this reports the number with an unknown state rather than hiding.
+            _ if flag_unknown => State::Unknown,
+            AC_OFFLINE => State::Discharging,
+            // Win32 has no distinct "charged" line status, so a full pack on AC
+            // is Full and anything below it is charging.
+            AC_ONLINE if percent >= 100.0 => State::Full,
+            AC_ONLINE => State::Charging,
+            _ => State::Unknown, // 255 = unknown, and any value Win32 adds later
+        };
+        Some(Battery { percent, state })
+    }
+
+    /// The `SYSTEM_POWER_STATUS` layout from `winbase.h`. Field names keep their
+    /// Win32 spelling so the struct can be checked against the docs at a glance,
+    /// and all six fields are declared even though three are unread — the layout
+    /// has to match what `kernel32` writes.
+    #[cfg(windows)]
+    #[repr(C)]
+    #[allow(non_snake_case, dead_code)]
+    struct SystemPowerStatus {
+        ACLineStatus: u8,
+        BatteryFlag: u8,
+        BatteryLifePercent: u8,
+        SystemStatusFlag: u8,
+        BatteryLifeTime: u32,
+        BatteryFullLifeTime: u32,
+    }
+
+    #[cfg(windows)]
+    #[link(name = "kernel32")]
+    #[allow(non_snake_case)]
+    extern "system" {
+        /// Fills `status` with the machine's power state; returns 0 on failure.
+        fn GetSystemPowerStatus(status: *mut SystemPowerStatus) -> i32;
+    }
+
+    /// Read the machine's power status, or `None` when the call fails or the
+    /// host has no battery.
+    #[cfg(windows)]
+    pub fn probe() -> Option<Battery> {
+        // SAFETY: `SystemPowerStatus` is six integers, so an all-zero bit
+        // pattern is a valid value of it.
+        let mut status: SystemPowerStatus = unsafe { std::mem::zeroed() };
+        // SAFETY: `status` is a live, correctly sized, caller-owned
+        // SYSTEM_POWER_STATUS; the call only writes into it.
+        if unsafe { GetSystemPowerStatus(&mut status) } == 0 {
+            return None; // the call failed — hide rather than guess
+        }
+        map(
+            status.ACLineStatus,
+            status.BatteryFlag,
+            status.BatteryLifePercent,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    // ---- shared: the percentage gate ----------------------------------------
+
+    #[test]
+    fn checked_percent_clamps_the_range_and_rejects_non_numbers() {
+        assert_eq!(checked_percent(42.5), Some(42.5));
+        assert_eq!(checked_percent(0.0), Some(0.0));
+        assert_eq!(checked_percent(100.0), Some(100.0));
+        // A miscalibrated pack over-reports; a dying one under-reports.
+        assert_eq!(checked_percent(137.0), Some(100.0));
+        assert_eq!(checked_percent(-4.0), Some(0.0));
+        // NaN/inf would render as `NaN%` — nothing to show.
+        assert_eq!(checked_percent(f64::NAN), None);
+        assert_eq!(checked_percent(f64::INFINITY), None);
+        assert_eq!(checked_percent(f64::NEG_INFINITY), None);
+    }
+
+    // ---- Linux: pure status + aggregation -----------------------------------
+
+    #[test]
+    fn sysfs_state_maps_every_kernel_status() {
+        assert_eq!(sysfs::parse_state("Charging"), State::Charging);
+        assert_eq!(sysfs::parse_state("Discharging"), State::Discharging);
+        assert_eq!(sysfs::parse_state("Full"), State::Full);
+        assert_eq!(sysfs::parse_state("Not charging"), State::NotCharging);
+        assert_eq!(sysfs::parse_state("Unknown"), State::Unknown);
+        // Missing file (empty string), odd casing, and vendor junk all decline
+        // to guess rather than pick a plausible-looking state.
+        assert_eq!(sysfs::parse_state(""), State::Unknown);
+        assert_eq!(sysfs::parse_state("charging"), State::Unknown);
+        assert_eq!(sysfs::parse_state("Whatever"), State::Unknown);
+    }
+
+    #[test]
+    fn sysfs_aggregate_of_nothing_is_no_battery() {
+        assert_eq!(sysfs::aggregate(&[]), None);
+    }
+
+    #[test]
+    fn sysfs_aggregate_passes_a_single_pack_through() {
+        let one = supply(63.0, State::Discharging, Some((6300.0, 10000.0)));
+        assert_eq!(
+            sysfs::aggregate(&[one]),
+            Some(Battery {
+                percent: 63.0,
+                state: State::Discharging,
+            })
+        );
+    }
+
+    #[test]
+    fn sysfs_aggregate_sums_energy_across_unequal_packs() {
+        // 90% of 20 Wh + 10% of 80 Wh = 26 Wh of 100 Wh. Averaging the
+        // percentages would claim 50%, which is the bug this guards.
+        let packs = [
+            supply(90.0, State::Discharging, Some((18000.0, 20000.0))),
+            supply(10.0, State::Discharging, Some((8000.0, 80000.0))),
+        ];
+        assert_eq!(sysfs::aggregate(&packs).unwrap().percent, 26.0);
+    }
+
+    #[test]
+    fn sysfs_aggregate_averages_capacity_when_any_pack_lacks_energy() {
+        // The second pack exports only `capacity`, so the summed-energy path is
+        // off the table for the whole host.
+        let packs = [
+            supply(80.0, State::Full, Some((8000.0, 10000.0))),
+            supply(20.0, State::Full, None),
+        ];
+        assert_eq!(sysfs::aggregate(&packs).unwrap().percent, 50.0);
+    }
+
+    #[test]
+    fn sysfs_aggregate_lets_charging_win() {
+        let packs = [
+            supply(50.0, State::Discharging, None),
+            supply(50.0, State::Charging, None),
+            supply(50.0, State::Full, None),
+        ];
+        assert_eq!(sysfs::aggregate(&packs).unwrap().state, State::Charging);
+    }
+
+    #[test]
+    fn sysfs_aggregate_prefers_discharging_over_a_full_pack() {
+        // A topped-up pack beside a draining one must not read as "Full".
+        let packs = [
+            supply(100.0, State::Full, None),
+            supply(30.0, State::Discharging, None),
+        ];
+        assert_eq!(sysfs::aggregate(&packs).unwrap().state, State::Discharging);
+    }
+
+    #[test]
+    fn sysfs_aggregate_falls_back_to_the_first_pack_state() {
+        let packs = [
+            supply(70.0, State::NotCharging, None),
+            supply(70.0, State::Unknown, None),
+        ];
+        assert_eq!(sysfs::aggregate(&packs).unwrap().state, State::NotCharging);
+    }
+
+    #[test]
+    fn sysfs_aggregate_keeps_a_single_packs_own_percentage() {
+        // The pack's `capacity` (42%) disagrees with its raw pair (10%);
+        // `read_supply` already picked the kernel's figure, so summing the pair
+        // here would quietly undo that choice.
+        let one = supply(42.0, State::Full, Some((10.0, 100.0)));
+        assert_eq!(sysfs::aggregate(&[one]).unwrap().percent, 42.0);
+    }
+
+    #[test]
+    fn sysfs_aggregate_survives_a_zero_capacity_pair() {
+        // `read_supply` never builds this, but a bad kernel driver would make
+        // the sum unusable — fall back to the averaged percentages, not NaN.
+        let packs = [
+            supply(44.0, State::Full, Some((0.0, 0.0))),
+            supply(46.0, State::Full, Some((0.0, 0.0))),
+        ];
+        assert_eq!(sysfs::aggregate(&packs).unwrap().percent, 45.0);
+    }
+
+    #[test]
+    fn sysfs_aggregate_clamps_an_over_full_pack() {
+        // Post-calibration packs report `energy_now > energy_full`.
+        let packs = [
+            supply(100.0, State::Full, Some((11000.0, 10000.0))),
+            supply(100.0, State::Full, Some((10500.0, 10000.0))),
+        ];
+        assert_eq!(sysfs::aggregate(&packs).unwrap().percent, 100.0);
+    }
+
+    // ---- Linux: the real directory walk over a fixture tree -----------------
+
+    #[test]
+    fn sysfs_walk_reads_capacity_and_status_from_a_real_tree() {
+        let root = scratch("walk");
+        supply_dir(
+            &root,
+            "BAT0",
+            &[("type", "Battery"), ("capacity", "77"), ("status", "Full")],
+        );
+
+        assert_eq!(
+            sysfs::read_from_root(&root),
+            Some(Battery {
+                percent: 77.0,
+                state: State::Full,
+            })
+        );
+        cleanup(&root);
+    }
+
+    #[test]
+    fn sysfs_walk_prefers_capacity_then_energy_then_charge() {
+        let root = scratch("percent-sources");
+
+        // `capacity` wins even when the energy pair disagrees with it.
+        let by_capacity = root.join("by-capacity");
+        supply_dir(
+            &by_capacity,
+            "BAT0",
+            &[
+                ("type", "Battery"),
+                ("capacity", "42"),
+                ("energy_now", "10"),
+                ("energy_full", "100"),
+            ],
+        );
+        assert_eq!(sysfs::read_from_root(&by_capacity).unwrap().percent, 42.0);
+
+        // No `capacity`: the energy pair beats the charge pair.
+        let by_energy = root.join("by-energy");
+        supply_dir(
+            &by_energy,
+            "BAT0",
+            &[
+                ("type", "Battery"),
+                ("energy_now", "3000"),
+                ("energy_full", "12000"),
+                ("charge_now", "1"),
+                ("charge_full", "2"),
+            ],
+        );
+        assert_eq!(sysfs::read_from_root(&by_energy).unwrap().percent, 25.0);
+
+        // Neither: the older `charge_*` pair is the last resort.
+        let by_charge = root.join("by-charge");
+        supply_dir(
+            &by_charge,
+            "BAT0",
+            &[
+                ("type", "Battery"),
+                ("charge_now", "1500"),
+                ("charge_full", "2000"),
+            ],
+        );
+        assert_eq!(sysfs::read_from_root(&by_charge).unwrap().percent, 75.0);
+
+        cleanup(&root);
+    }
+
+    #[test]
+    fn sysfs_walk_skips_mains_and_peripheral_batteries() {
+        let root = scratch("filter");
+        // An AC adapter, a Logitech mouse, and the machine's own pack.
+        supply_dir(&root, "AC", &[("type", "Mains"), ("online", "1")]);
+        supply_dir(
+            &root,
+            "hidpp_battery_0",
+            &[
+                ("type", "Battery"),
+                ("scope", "Device"),
+                ("capacity", "40"),
+                ("status", "Discharging"),
+            ],
+        );
+        supply_dir(
+            &root,
+            "BAT0",
+            &[
+                ("type", "Battery"),
+                ("capacity", "88"),
+                ("status", "Charging"),
+            ],
+        );
+
+        assert_eq!(
+            sysfs::read_from_root(&root),
+            Some(Battery {
+                percent: 88.0,
+                state: State::Charging,
+            }),
+            "only BAT0 counts — the adapter and the mouse are not the machine",
+        );
+
+        // A desktop with a wireless mouse plugged in has NO machine battery:
+        // reporting the mouse here is the exact failure the scope filter exists
+        // to prevent.
+        let peripherals_only = scratch("filter-mouse-only");
+        supply_dir(&peripherals_only, "AC", &[("type", "Mains")]);
+        supply_dir(
+            &peripherals_only,
+            "hidpp_battery_0",
+            &[("type", "Battery"), ("scope", "Device"), ("capacity", "40")],
+        );
+        assert_eq!(sysfs::read_from_root(&peripherals_only), None);
+
+        cleanup(&root);
+        cleanup(&peripherals_only);
+    }
+
+    #[test]
+    fn sysfs_walk_sums_two_packs_from_a_real_tree() {
+        let root = scratch("multi");
+        supply_dir(
+            &root,
+            "BAT0",
+            &[
+                ("type", "Battery"),
+                ("energy_now", "18000"),
+                ("energy_full", "20000"),
+                ("status", "Discharging"),
+            ],
+        );
+        supply_dir(
+            &root,
+            "BAT1",
+            &[
+                ("type", "Battery"),
+                ("energy_now", "8000"),
+                ("energy_full", "80000"),
+                ("status", "Charging"),
+            ],
+        );
+
+        assert_eq!(
+            sysfs::read_from_root(&root),
+            Some(Battery {
+                percent: 26.0, // 26000 µWh of 100000 µWh
+                state: State::Charging,
+            })
+        );
+        cleanup(&root);
+    }
+
+    #[test]
+    fn sysfs_walk_skips_malformed_empty_and_missing_files() {
+        let root = scratch("malformed");
+        // Unparseable capacity with no pair to fall back on.
+        supply_dir(&root, "BAT0", &[("type", "Battery"), ("capacity", "n/a")]);
+        // Empty `type` file.
+        supply_dir(&root, "BAT1", &[("type", ""), ("capacity", "50")]);
+        // No `type` file at all.
+        supply_dir(&root, "BAT2", &[("capacity", "50")]);
+        // A zeroed `energy_full` would be a division by zero.
+        supply_dir(
+            &root,
+            "BAT3",
+            &[
+                ("type", "Battery"),
+                ("energy_now", "10"),
+                ("energy_full", "0"),
+            ],
+        );
+        // `nan` parses as an f64 but is not a reading.
+        supply_dir(&root, "BAT4", &[("type", "Battery"), ("capacity", "nan")]);
+        // A stray plain file where a directory is expected.
+        std::fs::write(root.join("stray"), "junk").expect("fixture stray file");
+
+        assert_eq!(sysfs::read_from_root(&root), None);
+        cleanup(&root);
+    }
+
+    #[test]
+    fn sysfs_walk_clamps_both_ends() {
+        let root = scratch("clamp");
+
+        let over = root.join("over");
+        supply_dir(
+            &over,
+            "BAT0",
+            &[
+                ("type", "Battery"),
+                ("energy_now", "11000"),
+                ("energy_full", "10000"),
+            ],
+        );
+        assert_eq!(sysfs::read_from_root(&over).unwrap().percent, 100.0);
+
+        let under = root.join("under");
+        supply_dir(&under, "BAT0", &[("type", "Battery"), ("capacity", "-5")]);
+        assert_eq!(sysfs::read_from_root(&under).unwrap().percent, 0.0);
+
+        cleanup(&root);
+    }
+
+    #[test]
+    fn sysfs_walk_of_a_missing_root_is_no_battery() {
+        let root = scratch("absent");
+        let missing = root.join("no-such-power-supply-tree");
+        assert_eq!(sysfs::read_from_root(&missing), None);
+        cleanup(&root);
+    }
+
+    #[test]
+    fn sysfs_walk_of_an_empty_root_is_no_battery() {
+        // A VM registers the class directory but nothing inside it.
+        let root = scratch("empty-root");
+        assert_eq!(sysfs::read_from_root(&root), None);
+        cleanup(&root);
+    }
+
+    // ---- the host itself ----------------------------------------------------
+
+    #[test]
+    fn read_hides_the_metric_on_a_battery_less_host() {
+        let reading = read();
+
+        #[cfg(target_os = "linux")]
+        {
+            // This build box and our CI runners are VMs: `/sys/class/power_supply`
+            // is either absent or empty, so the whole hide path — walk, filter,
+            // aggregate, `None` — runs for real right here. A developer running
+            // the suite on a laptop has entries in the tree and legitimately
+            // gets a reading, so assert whatever the hardware justifies.
+            let root = std::path::Path::new(sysfs::ROOT);
+            let no_supplies = std::fs::read_dir(root)
+                .map(|entries| entries.count() == 0)
+                .unwrap_or(true);
+            if no_supplies {
+                assert_eq!(reading, None, "no power supplies means no battery");
+            }
+        }
+
+        // Everywhere else all we can assert is that the probe is total: it
+        // either declines or returns a renderable number.
+        if let Some(battery) = reading {
+            assert!((0.0..=100.0).contains(&battery.percent));
+        }
+    }
+
+    // ---- macOS: the pmset parser --------------------------------------------
+
+    /// The `Now drawing from` header every `pmset -g batt` run prints first.
+    const PMSET_HEADER: &str = "Now drawing from 'AC Power'\n";
+
+    #[test]
+    fn pmset_parses_a_charging_laptop() {
+        let out = format!(
+            "{PMSET_HEADER} -InternalBattery-0 (id=12345)\t97%; charging; 1:23 remaining present: true\n"
+        );
+        assert_eq!(
+            pmset::parse(&out),
+            Some(Battery {
+                percent: 97.0,
+                state: State::Charging,
+            })
+        );
+    }
+
+    #[test]
+    fn pmset_parses_a_discharging_laptop() {
+        let out = "Now drawing from 'Battery Power'\n \
+                   -InternalBattery-0 (id=12345)\t41%; discharging; 2:05 remaining present: true\n";
+        assert_eq!(
+            pmset::parse(out),
+            Some(Battery {
+                percent: 41.0,
+                state: State::Discharging,
+            })
+        );
+    }
+
+    #[test]
+    fn pmset_charged_and_finishing_charge_are_both_full() {
+        let charged = format!(
+            "{PMSET_HEADER} -InternalBattery-0 (id=12345)\t100%; charged; 0:00 remaining present: true\n"
+        );
+        assert_eq!(
+            pmset::parse(&charged),
+            Some(Battery {
+                percent: 100.0,
+                state: State::Full,
+            })
+        );
+
+        let finishing = format!(
+            "{PMSET_HEADER} -InternalBattery-0 (id=12345)\t99%; finishing charge; 0:04 remaining present: true\n"
+        );
+        assert_eq!(
+            pmset::parse(&finishing),
+            Some(Battery {
+                percent: 99.0,
+                state: State::Full,
+            })
+        );
+    }
+
+    #[test]
+    fn pmset_ac_attached_is_not_charging() {
+        // Battery health management holds the charge: plugged in, not moving.
+        // Note the capital `AC` — the match has to be case-insensitive.
+        let out = format!(
+            "{PMSET_HEADER} -InternalBattery-0 (id=12345)\t80%; AC attached; not charging present: true\n"
+        );
+        assert_eq!(
+            pmset::parse(&out),
+            Some(Battery {
+                percent: 80.0,
+                state: State::NotCharging,
+            })
+        );
+    }
+
+    #[test]
+    fn pmset_unknown_state_word_still_reports_the_percentage() {
+        let out = format!(
+            "{PMSET_HEADER} -InternalBattery-0 (id=12345)\t55%; hibernating; 0:00 remaining present: true\n"
+        );
+        assert_eq!(
+            pmset::parse(&out),
+            Some(Battery {
+                percent: 55.0,
+                state: State::Unknown,
+            })
+        );
+    }
+
+    #[test]
+    fn pmset_desktop_output_has_no_battery() {
+        // A Mac mini or Studio prints the header and nothing else.
+        assert_eq!(pmset::parse(PMSET_HEADER), None);
+    }
+
+    #[test]
+    fn pmset_absent_pack_is_no_battery() {
+        let out = format!(
+            "{PMSET_HEADER} -InternalBattery-0 (id=12345)\t0%; discharging; 0:00 remaining present: false\n"
+        );
+        assert_eq!(pmset::parse(&out), None);
+    }
+
+    #[test]
+    fn pmset_skips_an_absent_pack_and_takes_the_next_present_one() {
+        let out = format!(
+            "{PMSET_HEADER}\
+             -InternalBattery-0 (id=12345)\t0%; discharging; 0:00 remaining present: false\n\
+             -InternalBattery-1 (id=67890)\t64%; discharging; 3:11 remaining present: true\n"
+        );
+        assert_eq!(
+            pmset::parse(&out),
+            Some(Battery {
+                percent: 64.0,
+                state: State::Discharging,
+            })
+        );
+    }
+
+    #[test]
+    fn pmset_garbage_input_is_no_battery() {
+        assert_eq!(pmset::parse(""), None);
+        assert_eq!(pmset::parse("\n\n\t \n"), None);
+        assert_eq!(pmset::parse("command not found: pmset"), None);
+        // A battery line with no percentage has nothing to render.
+        assert_eq!(
+            pmset::parse(" -InternalBattery-0 (id=12345)\t; charging; present: true"),
+            None
+        );
+        // ..and neither does one whose percentage is not a number.
+        assert_eq!(
+            pmset::parse(" -InternalBattery-0 (id=12345)\tNaN%; charging; present: true"),
+            None
+        );
+    }
+
+    #[test]
+    fn pmset_clamps_an_over_hundred_percent_pack() {
+        let out =
+            format!("{PMSET_HEADER} -InternalBattery-0 (id=12345)\t103%; charged; present: true\n");
+        assert_eq!(pmset::parse(&out).unwrap().percent, 100.0);
+    }
+
+    // ---- Windows: the SYSTEM_POWER_STATUS mapper ----------------------------
+
+    #[test]
+    fn windows_no_system_battery_flag_hides_the_metric() {
+        // 128 alone, and 128 OR'd with a charge level, are both "desktop".
+        assert_eq!(power_status::map(1, 128, 255), None);
+        assert_eq!(power_status::map(1, 128 | 1, 100), None);
+        assert_eq!(power_status::map(0, 128 | 8, 50), None);
+    }
+
+    #[test]
+    fn windows_unknown_flag_reports_the_percentage_with_an_unknown_state() {
+        // 255 has the 128 bit set but means "status unknown", not "no battery" —
+        // the sentinel must be ruled out before the bit test.
+        assert_eq!(
+            power_status::map(1, 255, 73),
+            Some(Battery {
+                percent: 73.0,
+                state: State::Unknown,
+            })
+        );
+        // ..and an unknown flag does not turn an offline AC line into a state.
+        assert_eq!(power_status::map(0, 255, 73).unwrap().state, State::Unknown);
+    }
+
+    #[test]
+    fn windows_unknown_percentage_hides_the_metric() {
+        assert_eq!(power_status::map(0, 1, 255), None);
+        assert_eq!(power_status::map(1, 8, 255), None);
+    }
+
+    #[test]
+    fn windows_ac_offline_is_discharging() {
+        assert_eq!(
+            power_status::map(0, 4, 17),
+            Some(Battery {
+                percent: 17.0,
+                state: State::Discharging,
+            })
+        );
+        // Even a full pack is discharging once the cable is out.
+        assert_eq!(
+            power_status::map(0, 1, 100).unwrap().state,
+            State::Discharging
+        );
+    }
+
+    #[test]
+    fn windows_ac_online_is_charging_until_it_is_full() {
+        assert_eq!(
+            power_status::map(1, 8, 64),
+            Some(Battery {
+                percent: 64.0,
+                state: State::Charging,
+            })
+        );
+        assert_eq!(
+            power_status::map(1, 1, 100),
+            Some(Battery {
+                percent: 100.0,
+                state: State::Full,
+            })
+        );
+    }
+
+    #[test]
+    fn windows_unknown_ac_line_is_unknown() {
+        assert_eq!(
+            power_status::map(255, 1, 30),
+            Some(Battery {
+                percent: 30.0,
+                state: State::Unknown,
+            })
+        );
+    }
+
+    // ---- fixture helpers ----------------------------------------------------
+
+    /// Terse [`sysfs::Supply`] builder for the aggregation tests.
+    fn supply(percent: f64, state: State, charge: Option<(f64, f64)>) -> sysfs::Supply {
+        sysfs::Supply {
+            percent,
+            state,
+            charge,
+        }
+    }
+
+    /// Unique scratch dir under the system tmpdir, keyed by test name + pid +
+    /// thread id so parallel test threads never collide (the same shape as the
+    /// daemon tests' helper).
+    fn scratch(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "space-usage-battery-test-{name}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id(),
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        dir
+    }
+
+    /// Write a fixture power-supply directory: `<root>/<name>/<attr>` holding
+    /// `<value>` for every pair, each with the trailing newline the kernel emits
+    /// so the readers' trimming is exercised for real.
+    fn supply_dir(root: &Path, name: &str, attrs: &[(&str, &str)]) {
+        let dir = root.join(name);
+        std::fs::create_dir_all(&dir).expect("fixture supply dir");
+        for (attr, value) in attrs {
+            std::fs::write(dir.join(attr), format!("{value}\n")).expect("fixture attribute");
+        }
+    }
+
+    /// Best-effort removal of a scratch tree once a test is done with it.
+    fn cleanup(root: &Path) {
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,17 @@ pub struct Config {
     /// gives it meaning, so an unknown value auto-detects instead of failing
     /// here.
     pub icons: String,
+    /// Naming for the battery cell, overriding herdr's `[ui] battery_label`.
+    ///
+    /// Battery lives here rather than only in herdr's config because herdr has
+    /// no battery of its own to label: `battery_label` is not a key it knows, so
+    /// putting it in herdr's `[ui]` makes `herdr server reload-config` report
+    /// `unknown config key ui.battery_label; ignoring key` on every reload.
+    /// Harmless but noisy, and needless — nothing outside this plugin renders a
+    /// battery, so there is no second surface to keep in step. `cpu_label` and
+    /// `ram_label` stay in herdr's config precisely because the sidebar's
+    /// system-usage header does share those.
+    pub battery_label: Option<String>,
 }
 
 impl Default for Config {
@@ -45,6 +56,7 @@ impl Default for Config {
             window_title_totals: true,
             battery: true,
             icons: "auto".to_string(),
+            battery_label: None,
         }
     }
 }
@@ -127,6 +139,18 @@ impl Labels {
 
     pub fn battery(&self) -> Option<&str> {
         self.battery.as_deref()
+    }
+
+    /// Apply the plugin config's own label overrides on top of herdr's.
+    ///
+    /// Only battery has one, for the reason given on [`Config::battery_label`].
+    /// Returning `Self` keeps the load-then-override pair a single expression at
+    /// each call site, so no caller can load the labels and forget the overrides.
+    pub fn with_overrides(mut self, config: &Config) -> Self {
+        if let Some(label) = &config.battery_label {
+            self.battery = Some(label.clone());
+        }
+        self
     }
 
     /// The word to print on surfaces that always spell one out regardless of
@@ -277,6 +301,7 @@ fn parse_config(text: &str) -> Config {
                 }
             }
             "window_title_totals" => cfg.window_title_totals = value != "false",
+            "battery_label" => cfg.battery_label = non_empty(value),
             "battery" => cfg.battery = value != "false",
             // Stored raw: naming the tiers in two places would let the parser
             // and `icons::resolve` disagree about what `Nerd-Font` means.
@@ -305,14 +330,32 @@ fn parse_herdr_labels(text: &str) -> Labels {
         if !in_ui {
             continue;
         }
+        // An EMPTY label reads as unset, not as "name nothing".
+        //
+        // herdr's own config ships these keys as commented-out templates with
+        // empty quotes and a note naming the glyph to paste:
+        //
+        //     # cpu_label = ""   #  nf-oct-cpu
+        //
+        // Uncommenting one without filling it in is the obvious first move, and
+        // honouring the blank literally would silently strip the naming off
+        // every row — leaving bare percentages and no clue why. Treating it as
+        // unset keeps the tier's own naming, which is the recoverable answer.
+        // This also matches `non_empty_env`, which reads an empty environment
+        // value as absent for the same reason.
         match parse_kv_line(line) {
-            Some(("cpu_label", value)) => labels.cpu = Some(value.to_string()),
-            Some(("ram_label", value)) => labels.ram = Some(value.to_string()),
-            Some(("battery_label", value)) => labels.battery = Some(value.to_string()),
+            Some(("cpu_label", value)) => labels.cpu = non_empty(value),
+            Some(("ram_label", value)) => labels.ram = non_empty(value),
+            Some(("battery_label", value)) => labels.battery = non_empty(value),
             _ => {}
         }
     }
     labels
+}
+
+/// `Some(owned)` for a non-empty string, `None` for an empty one.
+fn non_empty(value: &str) -> Option<String> {
+    (!value.is_empty()).then(|| value.to_string())
 }
 
 /// Section name inside a leading `[...]` table header (the `[^\]]+` up to the
@@ -522,6 +565,40 @@ mod tests {
         // Surfaces that always spell a word still get one.
         assert_eq!(labels.cpu_word(), "cpu");
         assert_eq!(labels.ram_word(), "ram");
+    }
+
+    #[test]
+    fn the_plugin_config_owns_the_battery_label() {
+        // herdr does not know `battery_label`, so putting it in herdr's [ui]
+        // makes every `reload-config` log `unknown config key`. The plugin
+        // config is its proper home, and it overrides herdr's if both are set.
+        let cfg = parse_config("battery_label = \"\u{f241}\"");
+        assert_eq!(cfg.battery_label.as_deref(), Some("\u{f241}"));
+
+        let from_herdr = parse_herdr_labels("[ui]\nbattery_label = \"HERDR\"\n");
+        assert_eq!(
+            from_herdr.clone().with_overrides(&cfg).battery(),
+            Some("\u{f241}")
+        );
+
+        // With nothing set plugin-side, herdr's value still applies.
+        let bare = Config::default();
+        assert_eq!(from_herdr.with_overrides(&bare).battery(), Some("HERDR"));
+    }
+
+    #[test]
+    fn an_empty_label_reads_as_unset_not_as_blank() {
+        // herdr ships these keys as commented templates with empty quotes:
+        //     # cpu_label = ""   #  nf-oct-cpu
+        // Uncommenting one without pasting a glyph must not strip the naming
+        // off every row and leave bare percentages.
+        let labels = parse_herdr_labels("[ui]\ncpu_label = \"\"\nram_label = \"\"\n");
+        assert_eq!(labels.cpu(), None);
+        assert_eq!(labels.ram(), None);
+        assert_eq!(labels.cpu_word(), "cpu");
+        // The same line with a real glyph pasted in IS set.
+        let filled = parse_herdr_labels("[ui]\ncpu_label = \"\u{f4bc}\"   # nf-oct-cpu\n");
+        assert_eq!(filled.cpu(), Some("\u{f4bc}"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -410,11 +410,15 @@ mod tests {
             parse_config("icons = nerdfont").icon_set(),
             IconSet::NerdFont,
         );
-        // A typo is cosmetic, never fatal: it falls back to auto-detection,
-        // which yields one of the two tiers that need no font installed.
+        // A typo is cosmetic, never fatal: it falls back to auto-detection.
+        // Which tier that yields depends on the host's installed fonts, so this
+        // asserts only what is true on every machine — auto never selects a
+        // font-dependent *emoji* tier, and never the gauge. The detector's own
+        // behaviour is pinned in `icons`, where the font probe is injectable and
+        // the outcome is therefore deterministic.
         assert!(matches!(
             parse_config("icons = bogus").icon_set(),
-            IconSet::Text | IconSet::Unicode,
+            IconSet::Text | IconSet::NerdFont,
         ));
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,22 +78,65 @@ impl Config {
     }
 }
 
-/// CPU / RAM / battery label tokens sourced from herdr's `[ui]` config
-/// (default cpu/ram/bat).
-#[derive(Debug, Clone)]
+/// Default naming for each metric when herdr's `[ui]` config sets none.
+pub const DEFAULT_CPU_LABEL: &str = "cpu";
+pub const DEFAULT_RAM_LABEL: &str = "ram";
+pub const DEFAULT_BATTERY_LABEL: &str = "bat";
+
+/// CPU / RAM / battery label tokens sourced from herdr's `[ui]` config.
+///
+/// Each is `None` until herdr's config actually names it. That distinction is
+/// load-bearing rather than tidiness: an explicit label *replaces* an icon
+/// tier's glyph (see [`crate::icons`]), so the renderer has to know whether the
+/// user chose a word or whether it is merely looking at a default. Inferring
+/// that by comparing against the default string cannot tell `cpu_label = "cpu"`
+/// apart from an unset key — which silently made the two behave differently for
+/// no reason a user could see.
+#[derive(Debug, Clone, Default)]
 pub struct Labels {
-    pub cpu: String,
-    pub ram: String,
-    pub battery: String,
+    cpu: Option<String>,
+    ram: Option<String>,
+    battery: Option<String>,
 }
 
-impl Default for Labels {
-    fn default() -> Self {
+impl Labels {
+    /// Build a set of labels directly, bypassing herdr's config file.
+    ///
+    /// `None` means "herdr named nothing for this metric", which is what lets an
+    /// icon tier supply its own naming. Test-only: production always arrives
+    /// here through [`parse_herdr_labels`], and an unused constructor on a
+    /// public type is an invitation to construct one some other way.
+    #[cfg(test)]
+    pub fn new(cpu: Option<&str>, ram: Option<&str>, battery: Option<&str>) -> Self {
         Self {
-            cpu: "cpu".to_string(),
-            ram: "ram".to_string(),
-            battery: "bat".to_string(),
+            cpu: cpu.map(str::to_string),
+            ram: ram.map(str::to_string),
+            battery: battery.map(str::to_string),
         }
+    }
+
+    /// The label herdr's config set for this metric, or `None` when it set none.
+    /// Feed these to the icon tier, which decides how an unnamed metric is drawn.
+    pub fn cpu(&self) -> Option<&str> {
+        self.cpu.as_deref()
+    }
+
+    pub fn ram(&self) -> Option<&str> {
+        self.ram.as_deref()
+    }
+
+    pub fn battery(&self) -> Option<&str> {
+        self.battery.as_deref()
+    }
+
+    /// The word to print on surfaces that always spell one out regardless of
+    /// tier — the full-width terminal report's columns and its total line.
+    pub fn cpu_word(&self) -> &str {
+        self.cpu().unwrap_or(DEFAULT_CPU_LABEL)
+    }
+
+    pub fn ram_word(&self) -> &str {
+        self.ram().unwrap_or(DEFAULT_RAM_LABEL)
     }
 }
 
@@ -263,9 +306,9 @@ fn parse_herdr_labels(text: &str) -> Labels {
             continue;
         }
         match parse_kv_line(line) {
-            Some(("cpu_label", value)) => labels.cpu = value.to_string(),
-            Some(("ram_label", value)) => labels.ram = value.to_string(),
-            Some(("battery_label", value)) => labels.battery = value.to_string(),
+            Some(("cpu_label", value)) => labels.cpu = Some(value.to_string()),
+            Some(("ram_label", value)) => labels.ram = Some(value.to_string()),
+            Some(("battery_label", value)) => labels.battery = Some(value.to_string()),
             _ => {}
         }
     }
@@ -280,25 +323,55 @@ fn section_name(line: &str) -> Option<&str> {
     (!inner.is_empty()).then_some(inner)
 }
 
-/// Split one flat `key = value` line into `(key, unquoted_value)`.
+/// Split one flat `key = value` line into `(key, value)`, unquoted and with any
+/// inline `#` comment removed.
 ///
 /// Deliberately naive, matching the subset of TOML these config files use: the
-/// key is one or more ASCII letters/underscores,
-/// the value is everything after the FIRST `=` with surrounding whitespace
-/// trimmed (non-empty required) and at most one leading and one trailing quote
-/// (`"` or `'`) removed. Inline `#` comments are NOT stripped — by design, to
-/// keep the parser predictable.
+/// key is one or more ASCII letters/underscores, and the value is everything
+/// after the FIRST `=`, handed to [`value_of`].
 fn parse_kv_line(line: &str) -> Option<(&str, &str)> {
     let (key, value) = line.split_once('=')?;
     let key = key.trim();
     if key.is_empty() || !key.bytes().all(|b| b.is_ascii_alphabetic() || b == b'_') {
         return None;
     }
-    let value = value.trim();
-    if value.is_empty() {
-        return None;
+    value_of(value.trim()).map(|value| (key, value))
+}
+
+/// The value of a `key = value` right-hand side.
+///
+/// **Quoted**: everything between the opening quote and the next matching one.
+/// Whatever follows is discarded, which is what makes an inline comment work.
+/// This is not cosmetic — herdr's own `config.toml` documents its keys with
+/// trailing comments, e.g.
+///
+/// ```toml
+/// cpu_label = ""   #  nf-oct-cpu
+/// ```
+///
+/// and the previous parser handed back `"   #  nf-oct-cpu` as the label, which
+/// then rendered verbatim into the sidebar. Anyone following herdr's own
+/// documented example got garbage.
+///
+/// An explicit `""` survives as an empty value rather than being rejected: for a
+/// label that is a meaningful setting — "name nothing, just show the number".
+///
+/// **Unquoted**: everything up to the first `#`, trimmed, and non-empty. One
+/// stray trailing quote is still forgiven, matching the older lenient
+/// behaviour so a half-quoted value keeps working.
+fn value_of(rest: &str) -> Option<&str> {
+    let quote = rest.chars().next()?;
+    if quote == '"' || quote == '\'' {
+        let body = &rest[quote.len_utf8()..];
+        return Some(match body.find(quote) {
+            Some(end) => &body[..end],
+            // Unterminated: fall back to lenient stripping rather than dropping
+            // a setting the user plainly meant.
+            None => strip_quotes(body),
+        });
     }
-    Some((key, strip_quotes(value)))
+    let bare = strip_quotes(rest.split('#').next().unwrap_or("").trim());
+    (!bare.is_empty()).then_some(bare)
 }
 
 /// Remove at most one leading and one trailing quote (`"` or `'`), independently
@@ -438,11 +511,27 @@ mod tests {
     // ---- herdr labels: [ui] gating + quotes ---------------------------------
 
     #[test]
-    fn labels_default_when_no_ui_section() {
+    fn labels_are_unset_when_there_is_no_ui_section() {
         let labels = parse_herdr_labels("[server]\ncpu_label = \"NOPE\"\n");
-        assert_eq!(labels.cpu, "cpu");
-        assert_eq!(labels.ram, "ram");
-        assert_eq!(labels.battery, "bat");
+        // Unset, NOT "the default string": the renderer treats a label the user
+        // actually chose differently from one it invented, so the two must not
+        // collapse into the same value here.
+        assert_eq!(labels.cpu(), None);
+        assert_eq!(labels.ram(), None);
+        assert_eq!(labels.battery(), None);
+        // Surfaces that always spell a word still get one.
+        assert_eq!(labels.cpu_word(), "cpu");
+        assert_eq!(labels.ram_word(), "ram");
+    }
+
+    #[test]
+    fn a_label_set_to_the_default_word_is_still_explicitly_set() {
+        // The distinction the old string-comparison could not make. Someone who
+        // writes `cpu_label = "cpu"` has chosen a word, and a glyph tier must
+        // honour that choice rather than treating it as "nothing configured".
+        let labels = parse_herdr_labels("[ui]\ncpu_label = \"cpu\"\n");
+        assert_eq!(labels.cpu(), Some("cpu"));
+        assert_eq!(labels.ram(), None);
     }
 
     #[test]
@@ -457,9 +546,9 @@ mod tests {
             ram_label = \"WRONG\"\n\
             battery_label = \"WRONG\"\n";
         let labels = parse_herdr_labels(text);
-        assert_eq!(labels.cpu, "C"); // from [ui], not [ui.toast]
-        assert_eq!(labels.ram, "M");
-        assert_eq!(labels.battery, "PWR");
+        assert_eq!(labels.cpu(), Some("C")); // from [ui], not [ui.toast]
+        assert_eq!(labels.ram(), Some("M"));
+        assert_eq!(labels.battery(), Some("PWR"));
     }
 
     #[test]
@@ -469,15 +558,15 @@ mod tests {
             [ui]\n\
             ram_label = \"R\"\n";
         let labels = parse_herdr_labels(text);
-        assert_eq!(labels.cpu, "cpu"); // key before any section is ignored
-        assert_eq!(labels.ram, "R");
+        assert_eq!(labels.cpu(), None); // key before any section is ignored
+        assert_eq!(labels.ram(), Some("R"));
     }
 
     #[test]
     fn labels_section_header_is_trimmed_before_matching() {
         // `[ ui ]` still counts as the ui table — the name is trimmed.
         let labels = parse_herdr_labels("[ ui ]\ncpu_label = X\n");
-        assert_eq!(labels.cpu, "X");
+        assert_eq!(labels.cpu(), Some("X"));
     }
 
     // ---- shared helpers ------------------------------------------------------
@@ -491,6 +580,33 @@ mod tests {
         assert_eq!(strip_quotes("\"foo'"), "foo"); // mismatched
         assert_eq!(strip_quotes("\""), ""); // lone quote collapses to empty
         assert_eq!(strip_quotes("bare"), "bare");
+    }
+
+    #[test]
+    fn parse_kv_line_strips_inline_comments_from_herdrs_own_config_style() {
+        // herdr's config.toml documents its keys with trailing comments. The
+        // parser used to hand the whole tail back as the value, so following
+        // herdr's own example put `"   #  nf-oct-cpu` in the sidebar.
+        assert_eq!(
+            parse_kv_line(r#"cpu_label = "X"   #  nf-oct-cpu"#),
+            Some(("cpu_label", "X")),
+        );
+        assert_eq!(
+            parse_kv_line("interval_seconds = 12  # seconds"),
+            Some(("interval_seconds", "12")),
+        );
+        assert_eq!(
+            parse_kv_line("mode = sidebar # why"),
+            Some(("mode", "sidebar"))
+        );
+        // A `#` INSIDE quotes is part of the value, not a comment.
+        assert_eq!(
+            parse_kv_line(r##"cpu_label = "#1""##),
+            Some(("cpu_label", "#1"))
+        );
+        // An explicit empty string is a real setting — "name nothing" — and must
+        // survive rather than being rejected as a missing value.
+        assert_eq!(parse_kv_line(r#"cpu_label = """#), Some(("cpu_label", "")));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,12 +2,16 @@
 //!
 //! - [`load_config`] parses `$HERDR_PLUGIN_CONFIG_DIR/config.toml` (flat
 //!   `key = value` lines).
-//! - [`load_herdr_labels`] reads `cpu_label` / `ram_label` from herdr's OWN
-//!   `[ui]` section so per-space rows match the patched sidebar header.
+//! - [`load_herdr_labels`] reads `cpu_label` / `ram_label` / `battery_label`
+//!   from herdr's OWN `[ui]` section so per-space rows match the patched
+//!   sidebar header.
 //! - The path helpers resolve the herdr-injected env (`HERDR_PLUGIN_*`) with the
 //!   same `<tmpdir>/<id>` fallbacks the runtime uses.
 
 use std::path::PathBuf;
+
+use crate::battery::{self, Battery};
+use crate::icons::{self, IconSet};
 
 /// Status-surfacing strategy (plugin `config.toml` `mode`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -24,6 +28,13 @@ pub struct Config {
     pub mode: Mode,
     pub interval_seconds: u64,
     pub window_title_totals: bool,
+    /// Whether to show the battery cell at all. On by default; a host with no
+    /// battery hides it regardless (see [`Config::battery_reading`]).
+    pub battery: bool,
+    /// Glyph tier name as the user typed it — [`crate::icons::resolve`] is what
+    /// gives it meaning, so an unknown value auto-detects instead of failing
+    /// here.
+    pub icons: String,
 }
 
 impl Default for Config {
@@ -32,15 +43,48 @@ impl Default for Config {
             mode: Mode::AgentsPanel,
             interval_seconds: 5,
             window_title_totals: true,
+            battery: true,
+            icons: "auto".to_string(),
         }
     }
 }
 
-/// CPU / RAM label tokens sourced from herdr's `[ui]` config (default cpu/ram).
+impl Config {
+    /// The glyph tier this config selects.
+    ///
+    /// Resolve once per refresh and pass the result down: the answer depends on
+    /// the locale environment, which cannot change while the process runs, so
+    /// re-resolving per space would be pure repetition.
+    pub fn icon_set(&self) -> IconSet {
+        icons::resolve(Some(&self.icons))
+    }
+
+    /// The machine-wide battery reading for one refresh cycle, or `None` when
+    /// this host has no battery or the user turned the metric off.
+    ///
+    /// The `battery = false` gate lives here, at the *read*, rather than at each
+    /// place a cell is drawn. An opted-out user then pays nothing for the metric
+    /// — no sysfs walk on Linux, no `pmset` child process on macOS — and every
+    /// surface downstream (sidebar, window title, terminal report, JSON) is off
+    /// by construction instead of by four separate checks that could drift.
+    /// Turning the metric off therefore looks exactly like a desktop to the
+    /// renderers, which is the honest answer: there is no reading to show.
+    ///
+    /// Call this ONCE per refresh and pass the `Option<Battery>` down. A battery
+    /// is one value for the whole machine, so calling it per space would re-walk
+    /// sysfs (or fork `pmset`) once per space to be told the same thing.
+    pub fn battery_reading(&self) -> Option<Battery> {
+        self.battery.then(battery::read).flatten()
+    }
+}
+
+/// CPU / RAM / battery label tokens sourced from herdr's `[ui]` config
+/// (default cpu/ram/bat).
 #[derive(Debug, Clone)]
 pub struct Labels {
     pub cpu: String,
     pub ram: String,
+    pub battery: String,
 }
 
 impl Default for Labels {
@@ -48,6 +92,7 @@ impl Default for Labels {
         Self {
             cpu: "cpu".to_string(),
             ram: "ram".to_string(),
+            battery: "bat".to_string(),
         }
     }
 }
@@ -75,7 +120,8 @@ pub fn load_config() -> Config {
     }
 }
 
-/// Load `cpu_label` / `ram_label` from herdr's `[ui]` config section.
+/// Load `cpu_label` / `ram_label` / `battery_label` from herdr's `[ui]` config
+/// section.
 pub fn load_herdr_labels() -> Labels {
     match std::fs::read_to_string(herdr_config_path()) {
         Ok(text) => parse_herdr_labels(&text),
@@ -159,8 +205,10 @@ fn herdr_config_path() -> PathBuf {
 /// the documented defaults.
 ///
 /// Recognised keys: `mode` (`agents-panel` | `sidebar`), `interval_seconds`
-/// (numeric `>= 1`), `window_title_totals` (`false` only when it equals the
-/// literal `false`, any other value is truthy). Unknown keys are ignored.
+/// (numeric `>= 1`), `window_title_totals` and `battery` (`false` only when
+/// they equal the literal `false`, any other value is truthy), and `icons`
+/// (a tier name kept verbatim for [`crate::icons::resolve`]). Unknown keys are
+/// ignored.
 fn parse_config(text: &str) -> Config {
     let mut cfg = Config::default();
     for line in text.split('\n') {
@@ -186,14 +234,19 @@ fn parse_config(text: &str) -> Config {
                 }
             }
             "window_title_totals" => cfg.window_title_totals = value != "false",
+            "battery" => cfg.battery = value != "false",
+            // Stored raw: naming the tiers in two places would let the parser
+            // and `icons::resolve` disagree about what `Nerd-Font` means.
+            "icons" => cfg.icons = value.to_string(),
             _ => {}
         }
     }
     cfg
 }
 
-/// Parse herdr's OWN `config.toml` text for `cpu_label` / `ram_label`, reading
-/// them ONLY inside the `[ui]` section — not `[ui.toast]` or any other table.
+/// Parse herdr's OWN `config.toml` text for `cpu_label` / `ram_label` /
+/// `battery_label`, reading them ONLY inside the `[ui]` section — not
+/// `[ui.toast]` or any other table.
 fn parse_herdr_labels(text: &str) -> Labels {
     let mut labels = Labels::default();
     let mut in_ui = false;
@@ -212,6 +265,7 @@ fn parse_herdr_labels(text: &str) -> Labels {
         match parse_kv_line(line) {
             Some(("cpu_label", value)) => labels.cpu = value.to_string(),
             Some(("ram_label", value)) => labels.ram = value.to_string(),
+            Some(("battery_label", value)) => labels.battery = value.to_string(),
             _ => {}
         }
     }
@@ -268,6 +322,8 @@ mod tests {
         assert_eq!(cfg.mode, Mode::AgentsPanel);
         assert_eq!(cfg.interval_seconds, 5);
         assert!(cfg.window_title_totals);
+        assert!(cfg.battery, "the battery cell is on unless opted out");
+        assert_eq!(cfg.icons, "auto");
     }
 
     #[test]
@@ -325,6 +381,44 @@ mod tests {
     }
 
     #[test]
+    fn config_battery_false_only_on_literal_false() {
+        assert!(!parse_config("battery = false").battery);
+        assert!(!parse_config("battery = \"false\"").battery);
+        // Anything other than the literal `false` is truthy — same rule as
+        // `window_title_totals`, so the two booleans cannot drift apart.
+        assert!(parse_config("battery = true").battery);
+        assert!(parse_config("battery = 0").battery);
+    }
+
+    #[test]
+    fn config_battery_false_takes_no_reading_at_all() {
+        // The whole point of the gate: opting out costs zero syscalls, and
+        // every renderer downstream sees the same `None` a desktop produces.
+        // Hardware-independent — true on a laptop and on a VM alike.
+        let cfg = parse_config("battery = false");
+        assert_eq!(cfg.battery_reading(), None);
+    }
+
+    #[test]
+    fn config_icons_keeps_the_raw_tier_name() {
+        // The parser stores what the user typed; `icons::resolve` owns the
+        // vocabulary, including the case/separator folding it does.
+        assert_eq!(parse_config("icons = nerdfont").icons, "nerdfont");
+        assert_eq!(parse_config("icons = \"Nerd-Font\"").icons, "Nerd-Font");
+        assert_eq!(parse_config("icons = bogus").icons, "bogus");
+        assert_eq!(
+            parse_config("icons = nerdfont").icon_set(),
+            IconSet::NerdFont,
+        );
+        // A typo is cosmetic, never fatal: it falls back to auto-detection,
+        // which yields one of the two tiers that need no font installed.
+        assert!(matches!(
+            parse_config("icons = bogus").icon_set(),
+            IconSet::Text | IconSet::Unicode,
+        ));
+    }
+
+    #[test]
     fn config_skips_comments_and_malformed_lines() {
         let text = "\
             # mode = sidebar\n\
@@ -344,6 +438,7 @@ mod tests {
         let labels = parse_herdr_labels("[server]\ncpu_label = \"NOPE\"\n");
         assert_eq!(labels.cpu, "cpu");
         assert_eq!(labels.ram, "ram");
+        assert_eq!(labels.battery, "bat");
     }
 
     #[test]
@@ -352,12 +447,15 @@ mod tests {
             [ui]\n\
             cpu_label = \"C\"\n\
             ram_label = 'M'\n\
+            battery_label = \"PWR\"\n\
             [ui.toast]\n\
             cpu_label = \"WRONG\"\n\
-            ram_label = \"WRONG\"\n";
+            ram_label = \"WRONG\"\n\
+            battery_label = \"WRONG\"\n";
         let labels = parse_herdr_labels(text);
         assert_eq!(labels.cpu, "C"); // from [ui], not [ui.toast]
         assert_eq!(labels.ram, "M");
+        assert_eq!(labels.battery, "PWR");
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -78,7 +78,7 @@ pub fn run_daemon() -> crate::Result<()> {
     std::fs::write(config::pid_file(), format!("{}\n", std::process::id()))?;
 
     let config = config::load_config();
-    let labels = config::load_herdr_labels();
+    let labels = config::load_herdr_labels().with_overrides(&config);
     // The glyph tier depends on config and locale, neither of which changes
     // while we run, so it is resolved once here rather than per refresh.
     let icons = config.icon_set();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -40,6 +40,40 @@ pub struct Tracked {
     pub workspaces: HashSet<String>,
 }
 
+/// Everything the render path reads out of config, re-read together.
+///
+/// Grouped rather than passed as three loose values so a caller cannot refresh
+/// one and keep a stale copy of another — the labels and the icon tier decide
+/// the same row between them, and disagreeing copies would render a mixture.
+struct Settings {
+    config: Config,
+    labels: Labels,
+    icons: IconSet,
+}
+
+/// Re-read the plugin config and herdr's labels, and re-resolve the icon tier.
+///
+/// Called once per refresh so an edit to either config file reaches the sidebar
+/// on the next cycle instead of waiting for someone to restart the updater. That
+/// matters more than it sounds: herdr's own system-usage header renders from the
+/// same `cpu_label` / `ram_label`, and herdr reloads its config on demand, so a
+/// daemon holding a startup snapshot of those keys would show the old naming in
+/// the rows and the new one in the header — the two drifting apart with no
+/// indication why.
+///
+/// Cost is two small file reads. The font probe behind the tier is cached in a
+/// `OnceLock`, so re-resolving does not re-fork `fc-list`.
+fn reload_settings() -> Settings {
+    let config = config::load_config();
+    let labels = config::load_herdr_labels().with_overrides(&config);
+    let icons = config.icon_set();
+    Settings {
+        config,
+        labels,
+        icons,
+    }
+}
+
 /// PID of a live updater daemon, or `None` (missing pid file / dead process /
 /// a pid that no longer belongs to us).
 ///
@@ -77,11 +111,11 @@ pub fn run_daemon() -> crate::Result<()> {
     std::fs::create_dir_all(config::state_dir())?;
     std::fs::write(config::pid_file(), format!("{}\n", std::process::id()))?;
 
-    let config = config::load_config();
-    let labels = config::load_herdr_labels().with_overrides(&config);
-    // The glyph tier depends on config and locale, neither of which changes
-    // while we run, so it is resolved once here rather than per refresh.
-    let icons = config.icon_set();
+    // Re-read every cycle rather than once here — see `reload_settings`. The
+    // first read also fixes the refresh cadence for the life of the daemon,
+    // since that drives the sleep and the status TTL together.
+    let mut settings = reload_settings();
+    let daemon_interval_ms = settings.config.interval_seconds * 1000;
 
     let mut client = match herdr::connect() {
         Ok(client) => client,
@@ -123,11 +157,20 @@ pub fn run_daemon() -> crate::Result<()> {
     #[cfg(windows)]
     spawn_watchdog(Arc::clone(&heartbeat), started, config.interval_seconds);
 
-    let daemon_interval_ms = config.interval_seconds * 1000;
     let mut window_ms: u64 = 500; // quick first sample so the sidebar updates immediately
     let mut failures: u32 = 0;
     loop {
         heartbeat.store(started.elapsed().as_secs(), Ordering::SeqCst);
+        // Pick up config edits without an updater restart. Two small file reads
+        // per refresh, against a cadence measured in seconds — far cheaper than
+        // the `/proc` walk that just ran, and it is what keeps the sidebar rows
+        // in step with herdr's own system-usage header: both render from
+        // `cpu_label` / `ram_label`, so a stale copy here shows one naming above
+        // the other. The interval is deliberately NOT re-read; changing the
+        // cadence mid-flight would desynchronise the TTL from the refresh rate.
+        settings = reload_settings();
+        let (config, labels, icons) = (&settings.config, &settings.labels, settings.icons);
+
         match collect::snapshot(&mut client, window_ms) {
             Ok(spaces) => {
                 if stopping.load(Ordering::SeqCst) {
@@ -142,15 +185,15 @@ pub fn run_daemon() -> crate::Result<()> {
                     push_statuses(
                         &mut client,
                         &spaces,
-                        &config,
-                        &labels,
+                        config,
+                        labels,
                         icons,
                         battery,
                         &mut guard,
                     );
                 }
                 if config.window_title_totals {
-                    set_title_totals(&mut client, &spaces, &labels, icons, battery);
+                    set_title_totals(&mut client, &spaces, labels, icons, battery);
                 }
                 failures = 0;
             }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -19,11 +19,14 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
+use crate::battery::Battery;
 use crate::collect::{self, PSEUDO_AGENT};
 use crate::config::{self, Config, Labels, Mode};
 use crate::herdr::{self, Herdr};
+use crate::icons::IconSet;
 use crate::model::Space;
 use crate::proc;
+use crate::render;
 
 /// Panes we have pushed status onto this run, so shutdown can clear them.
 #[derive(Debug, Default)]
@@ -76,6 +79,9 @@ pub fn run_daemon() -> crate::Result<()> {
 
     let config = config::load_config();
     let labels = config::load_herdr_labels();
+    // The glyph tier depends on config and locale, neither of which changes
+    // while we run, so it is resolved once here rather than per refresh.
+    let icons = config.icon_set();
 
     let mut client = match herdr::connect() {
         Ok(client) => client,
@@ -127,12 +133,24 @@ pub fn run_daemon() -> crate::Result<()> {
                 if stopping.load(Ordering::SeqCst) {
                     park(); // shutdown ran during the sample window — do not re-report
                 }
+                // ONE reading per refresh: the battery is machine-wide, so the
+                // per-space push below must not re-walk sysfs (or fork `pmset`)
+                // for each space to be told the same number.
+                let battery = config.battery_reading();
                 {
                     let mut guard = tracked.lock().expect("tracked mutex poisoned");
-                    push_statuses(&mut client, &spaces, &config, &labels, &mut guard);
+                    push_statuses(
+                        &mut client,
+                        &spaces,
+                        &config,
+                        &labels,
+                        icons,
+                        battery,
+                        &mut guard,
+                    );
                 }
                 if config.window_title_totals {
-                    set_title_totals(&mut client, &spaces, &labels);
+                    set_title_totals(&mut client, &spaces, &labels, icons, battery);
                 }
                 failures = 0;
             }
@@ -249,18 +267,24 @@ pub fn toggle_updater() -> crate::Result<()> {
 /// spare pane; on success that space is done. sidebar mode (and the agents-panel
 /// fall-through when the pseudo report fails): release leftover pseudo-agents,
 /// then report TTL'd metadata on the first spare pane (else the first agent pane).
+///
+/// `icons` and `battery` are the once-per-refresh presentation inputs the caller
+/// resolved: both are machine-wide, so taking them as parameters is what keeps
+/// the per-space loop below from re-deriving them once per space.
 pub fn push_statuses(
     client: &mut Herdr,
     spaces: &[Space],
     config: &Config,
     labels: &Labels,
+    icons: IconSet,
+    battery: Option<Battery>,
     tracked: &mut Tracked,
 ) {
     let source = config::plugin_id();
     let ttl_ms = status_ttl_ms(config.interval_seconds);
 
     for sp in spaces {
-        let status = status_line(sp, labels);
+        let status = status_line(sp, labels, icons, battery);
 
         if config.mode == Mode::AgentsPanel {
             // Drop stale claims from earlier runs so a space keeps one entry.
@@ -351,22 +375,38 @@ pub fn clear_all(client: &mut Herdr, tracked: &Tracked) {
     }
 }
 
-/// Write the all-space CPU/RAM totals to the client window title.
-pub fn set_title_totals(client: &mut Herdr, spaces: &[Space], labels: &Labels) {
+/// Write the all-space CPU/RAM/battery totals to the client window title.
+pub fn set_title_totals(
+    client: &mut Herdr,
+    spaces: &[Space],
+    labels: &Labels,
+    icons: IconSet,
+    battery: Option<Battery>,
+) {
+    let _ = client.window_title_set(&title_totals(spaces, labels, icons, battery));
+}
+
+/// The window title text: `"spaces · "` plus the same row the sidebar card
+/// shows, summed over every space.
+///
+/// Pure, and split from [`set_title_totals`] so the formatting is testable
+/// without a live herdr connection.
+fn title_totals(
+    spaces: &[Space],
+    labels: &Labels,
+    icons: IconSet,
+    battery: Option<Battery>,
+) -> String {
     let mut cpu = 0.0;
     let mut ram_mb = 0.0;
     for sp in spaces {
         cpu += sp.cpu;
         ram_mb += sp.ram_mb;
     }
-    let title = format!(
-        "spaces · {} {}% · {} {}",
-        labels.cpu,
-        cpu.round() as i64,
-        labels.ram,
-        ram_display(ram_mb),
-    );
-    let _ = client.window_title_set(&title);
+    format!(
+        "spaces · {}",
+        render::usage_row(cpu, ram_mb, labels, icons, battery),
+    )
 }
 
 // ---- helpers ----------------------------------------------------------------
@@ -542,36 +582,10 @@ fn status_ttl_ms(interval_seconds: u64) -> u64 {
     interval_seconds.saturating_mul(3_000).min(MAX_TTL_MS)
 }
 
-/// The per-space status text: `"<cpu> <n>% · <ram> <pct-or-compact>"`.
-fn status_line(sp: &Space, labels: &Labels) -> String {
-    format!(
-        "{} {}% · {} {}",
-        labels.cpu,
-        sp.cpu.round() as i64,
-        labels.ram,
-        ram_display(sp.ram_mb),
-    )
-}
-
-/// RAM as a percent-of-total string, falling back to the compact absolute form
-/// when `/proc/meminfo` is unreadable.
-fn ram_display(mb: f64) -> String {
-    let pct = proc::ram_pct(mb);
-    if pct.is_empty() {
-        compact_ram(mb)
-    } else {
-        pct
-    }
-}
-
-/// Compact absolute RAM: `"<x.x>G"` at/above 1024 MB, else `"<n>M"`
-/// — the narrow form used by sidebar statuses.
-fn compact_ram(mb: f64) -> String {
-    if mb >= 1024.0 {
-        format!("{:.1}G", mb / 1024.0)
-    } else {
-        format!("{}M", mb.round() as i64)
-    }
+/// The per-space status text — `cpu ░26% · ram ░8% · bat ▓74%` in the Unicode
+/// tier, and the battery cell only when the host has one.
+fn status_line(sp: &Space, labels: &Labels, icons: IconSet, battery: Option<Battery>) -> String {
+    render::usage_row(sp.cpu, sp.ram_mb, labels, icons, battery)
 }
 
 /// Best-effort release of our pseudo-agent on `pane_id` (a closed pane errors and
@@ -590,6 +604,7 @@ fn notify(body: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::battery::State;
     use crate::config::Labels;
 
     fn space(cpu: f64, ram_mb: f64) -> Space {
@@ -598,6 +613,11 @@ mod tests {
             ram_mb,
             ..Default::default()
         }
+    }
+
+    /// Terse [`Battery`] builder for the cell tests.
+    fn bat(percent: f64, state: State) -> Battery {
+        Battery { percent, state }
     }
 
     #[test]
@@ -611,32 +631,129 @@ mod tests {
         assert_eq!(status_ttl_ms(u64::MAX), MAX_TTL_MS);
     }
 
-    #[test]
-    fn compact_ram_switches_unit_at_1024() {
-        assert_eq!(compact_ram(0.0), "0M");
-        assert_eq!(compact_ram(512.6), "513M"); // rounds to whole MB
-        assert_eq!(compact_ram(1023.4), "1023M"); // still MB below the gate
-        assert_eq!(compact_ram(1024.0), "1.0G");
-        assert_eq!(compact_ram(1536.0), "1.5G");
-    }
+    // ---- the sidebar status line --------------------------------------------
 
     #[test]
     fn status_line_uses_labels_and_rounds_cpu() {
         let labels = Labels {
             cpu: "CPU".to_string(),
             ram: "MEM".to_string(),
+            battery: "PWR".to_string(),
         };
-        // No /proc/meminfo total in most CI: ram_display falls back to compact.
-        // Assert the CPU rounding + label layout, which are total-independent.
-        let line = status_line(&space(5.6, 0.0), &labels);
+        // The RAM cell depends on the host's MemTotal (percent when readable,
+        // compact absolute when not), so assert the CPU rounding + label layout,
+        // which are total-independent. `render::ram_cell_of` pins both branches.
+        let line = status_line(&space(5.6, 0.0), &labels, IconSet::Text, None);
         assert!(line.starts_with("CPU 6% · MEM "), "got: {line}");
     }
 
     #[test]
     fn status_line_rounds_cpu_half_away_from_zero() {
         let labels = Labels::default();
-        assert!(status_line(&space(2.5, 0.0), &labels).starts_with("cpu 3%"));
-        assert!(status_line(&space(2.4, 0.0), &labels).starts_with("cpu 2%"));
+        let line = |cpu| status_line(&space(cpu, 0.0), &labels, IconSet::Text, None);
+        assert!(line(2.5).starts_with("cpu 3%"));
+        assert!(line(2.4).starts_with("cpu 2%"));
+    }
+
+    #[test]
+    fn status_line_adds_a_battery_cell_only_when_there_is_a_reading() {
+        let labels = Labels::default();
+        let sp = space(26.0, 0.0);
+        let with = status_line(
+            &sp,
+            &labels,
+            IconSet::Unicode,
+            Some(bat(74.0, State::Discharging)),
+        );
+        let without = status_line(&sp, &labels, IconSet::Unicode, None);
+
+        assert!(with.ends_with(" · bat ▓74%"), "got: {with}");
+        // A desktop/server/VM shows no battery at all — not `bat 0%`, and not a
+        // dangling separator.
+        assert!(!without.contains("bat"), "got: {without}");
+        // The cell is purely additive: everything before it is byte-identical.
+        assert_eq!(with.strip_suffix(" · bat ▓74%"), Some(without.as_str()));
+    }
+
+    #[test]
+    fn status_line_has_no_battery_cell_when_the_config_turns_it_off() {
+        // `battery = false` is honoured at the read, so an opted-out user gets
+        // exactly the row a battery-less host gets — on any hardware, which is
+        // what makes this assertion safe on a developer's laptop too.
+        let config = Config {
+            battery: false,
+            ..Config::default()
+        };
+        let line = status_line(
+            &space(26.0, 0.0),
+            &Labels::default(),
+            IconSet::Unicode,
+            config.battery_reading(),
+        );
+        assert!(!line.contains("bat"), "got: {line}");
+    }
+
+    #[test]
+    fn status_line_draws_the_cpu_and_battery_cells_in_every_tier() {
+        let labels = Labels::default();
+        let sp = space(26.0, 0.0);
+        // Head and tail of the row per tier; the RAM cell in the middle is
+        // host-dependent, so `render`'s tests pin the whole row instead.
+        let expected = [
+            (IconSet::Text, "cpu 26%", "bat 74%"),
+            (IconSet::Unicode, "cpu ░26%", "bat ▓74%"),
+            (IconSet::NerdFont, "\u{f4bc} 26%", "\u{f241} 74%"),
+            (IconSet::Emoji, "💻26%", "🔋74%"),
+        ];
+        for (icons, cpu, battery) in expected {
+            let line = status_line(&sp, &labels, icons, Some(bat(74.0, State::Discharging)));
+            assert!(line.starts_with(&format!("{cpu} · ")), "{icons:?}: {line}");
+            assert!(
+                line.ends_with(&format!(" · {battery}")),
+                "{icons:?}: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn status_line_battery_cell_shows_the_charge_state() {
+        // Same charge, three states: a glance at the sidebar has to tell a pack
+        // that is filling from one that is draining.
+        let labels = Labels::default();
+        let line = |state| {
+            status_line(
+                &space(26.0, 0.0),
+                &labels,
+                IconSet::Unicode,
+                Some(bat(74.0, state)),
+            )
+        };
+        assert!(line(State::Charging).ends_with("bat ▓74%+"));
+        assert!(line(State::Discharging).ends_with("bat ▓74%"));
+        assert!(line(State::Full).ends_with("bat ▓74%="));
+        assert_ne!(line(State::Charging), line(State::Discharging));
+    }
+
+    // ---- the window title ----------------------------------------------------
+
+    #[test]
+    fn title_totals_sums_the_spaces_and_carries_one_battery() {
+        let labels = Labels::default();
+        let spaces = [space(10.0, 0.0), space(16.4, 0.0)];
+        let with = title_totals(
+            &spaces,
+            &labels,
+            IconSet::Text,
+            Some(bat(74.0, State::Full)),
+        );
+        let without = title_totals(&spaces, &labels, IconSet::Text, None);
+
+        // 10.0 + 16.4 = 26.4, rounded once over the total rather than per space.
+        assert!(with.starts_with("spaces · cpu 26% · ram "), "got: {with}");
+        // One machine-wide cell on the title, `=` for a pack on power.
+        assert!(with.ends_with(" · bat 74%="), "got: {with}");
+        assert!(!without.contains("bat"), "got: {without}");
+        assert_eq!(with.strip_suffix(" · bat 74%="), Some(without.as_str()));
     }
 
     // ---- restart recovery ---------------------------------------------------

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -635,11 +635,7 @@ mod tests {
 
     #[test]
     fn status_line_uses_labels_and_rounds_cpu() {
-        let labels = Labels {
-            cpu: "CPU".to_string(),
-            ram: "MEM".to_string(),
-            battery: "PWR".to_string(),
-        };
+        let labels = Labels::new(Some("CPU"), Some("MEM"), Some("PWR"));
         // The RAM cell depends on the host's MemTotal (percent when readable,
         // compact absolute when not), so assert the CPU rounding + label layout,
         // which are total-independent. `render::ram_cell_of` pins both branches.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -154,8 +154,15 @@ pub fn run_daemon() -> crate::Result<()> {
     // Windows-only backstop for the read timeout unix gets from the socket.
     let started = std::time::Instant::now();
     let heartbeat = Arc::new(AtomicU64::new(0));
+    // The watchdog is sized off the cadence fixed at startup, which is the same
+    // one `daemon_interval_ms` uses — the interval is deliberately not re-read
+    // per cycle, so this stays correct for the daemon's whole life.
     #[cfg(windows)]
-    spawn_watchdog(Arc::clone(&heartbeat), started, config.interval_seconds);
+    spawn_watchdog(
+        Arc::clone(&heartbeat),
+        started,
+        settings.config.interval_seconds,
+    );
 
     let mut window_ms: u64 = 500; // quick first sample so the sidebar updates immediately
     let mut failures: u32 = 0;

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -34,7 +34,7 @@ use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 
 use crate::battery::{Battery, State};
-use crate::config::non_empty_env;
+use crate::config::{non_empty_env, DEFAULT_BATTERY_LABEL, DEFAULT_CPU_LABEL, DEFAULT_RAM_LABEL};
 
 /// Which glyph vocabulary to render metrics with.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -139,9 +139,9 @@ impl Metric {
     /// [`IconSet::render`].
     fn default_word(self) -> &'static str {
         match self {
-            Metric::Cpu => "cpu",
-            Metric::Ram => "ram",
-            Metric::Battery => "bat",
+            Metric::Cpu => DEFAULT_CPU_LABEL,
+            Metric::Ram => DEFAULT_RAM_LABEL,
+            Metric::Battery => DEFAULT_BATTERY_LABEL,
         }
     }
 
@@ -168,18 +168,18 @@ impl Metric {
 
 impl IconSet {
     /// Render CPU load — `cpu ░26%` in the [`IconSet::Unicode`] tier.
-    pub fn cpu(self, label: &str, percent: f64) -> String {
+    pub fn cpu(self, label: Option<&str>, percent: f64) -> String {
         self.render(Metric::Cpu, label, percent, None)
     }
 
     /// Render RAM use — `ram ░8%` in the [`IconSet::Unicode`] tier.
-    pub fn ram(self, label: &str, percent: f64) -> String {
+    pub fn ram(self, label: Option<&str>, percent: f64) -> String {
         self.render(Metric::Ram, label, percent, None)
     }
 
     /// Render a battery reading — `bat ▓74%+` for 74% and charging in the
     /// [`IconSet::Unicode`] tier.
-    pub fn battery(self, label: &str, reading: Battery) -> String {
+    pub fn battery(self, label: Option<&str>, reading: Battery) -> String {
         self.render(
             Metric::Battery,
             label,
@@ -188,42 +188,75 @@ impl IconSet {
         )
     }
 
+    /// This tier's naming as herdr `[ui]` label values: `(cpu, ram, battery)`.
+    ///
+    /// Exists so [`herdr_ui_snippet`] can hand the user a block that pins the
+    /// same naming into herdr's own config. That matters on a patched build,
+    /// where the sidebar's system-usage header renders from `cpu_label` /
+    /// `ram_label` and would otherwise keep saying `cpu`/`ram` in words while
+    /// these rows switched to icons — the drift this whole mechanism exists to
+    /// prevent.
+    ///
+    /// The battery ramp needs a percentage to pick a glyph, and a static config
+    /// value cannot ramp, so the full-battery glyph stands in for the family.
+    fn label_values(self) -> (String, String, String) {
+        let of = |metric: Metric| match self {
+            IconSet::Text | IconSet::Unicode => metric.default_word().to_string(),
+            IconSet::NerdFont => metric.nerd_glyph(100.0).to_string(),
+            IconSet::Emoji => metric.emoji().to_string(),
+        };
+        (of(Metric::Cpu), of(Metric::Ram), of(Metric::Battery))
+    }
+
     /// `[word ][glyph]<n>%[mark]` — the one assembly every tier and metric goes
     /// through, so the tiers cannot drift apart in spacing or ordering.
-    fn render(self, metric: Metric, label: &str, percent: f64, mark: Option<char>) -> String {
-        // The glyph tiers put a picture where the word would go, so they print a
-        // word only when the user actually chose one (herdr `[ui]` beats the
-        // tier — the config escape hatch has to keep working at every setting).
-        // Text and Unicode always carry it: there, the word is the only thing
-        // naming the number.
-        let names_metric = self.spells_out_the_word() || label != metric.default_word();
-        let word = if names_metric && !label.is_empty() {
-            format!("{label} ")
-        } else {
-            String::new() // an empty label must not leave a stray leading space
-        };
+    fn render(
+        self,
+        metric: Metric,
+        label: Option<&str>,
+        percent: f64,
+        mark: Option<char>,
+    ) -> String {
+        let mark = mark.map(String::from).unwrap_or_default();
+        let number = format!("{}%{mark}", round_percent(percent));
 
-        let glyph = match self {
-            IconSet::Text => String::new(),
-            // The gauge runs straight into the number it is measuring.
-            IconSet::Unicode => ramp_pick(&GAUGE_RAMP, percent).to_string(),
+        // An explicit herdr `[ui]` label REPLACES the tier's naming — it does not
+        // stack on top of it.
+        //
+        // This is what makes those labels a genuine single source of truth. On a
+        // patched build the sidebar's system-usage header renders from the same
+        // two keys, so a user who sets `cpu_label` once gets the header and these
+        // rows agreeing no matter which tier is active. Prefixing the label to
+        // the tier's glyph instead would draw the icon twice for exactly the
+        // user who took the trouble to configure it.
+        //
+        // An empty label is a deliberate "name nothing": no word, no glyph, no
+        // stray leading space.
+        if let Some(label) = label {
+            return if label.is_empty() {
+                number
+            } else {
+                format!("{label} {number}")
+            };
+        }
+
+        // No explicit label, so the tier decides how the metric is named.
+        let naming = match self {
+            IconSet::Text => format!("{} ", metric.default_word()),
+            // The word still carries the meaning; the gauge runs straight into
+            // the number it measures.
+            IconSet::Unicode => format!(
+                "{} {}",
+                metric.default_word(),
+                ramp_pick(&GAUGE_RAMP, percent)
+            ),
             // Nerd Font glyphs are drawn edge-to-edge in their cell; without the
             // space the digits touch them.
             IconSet::NerdFont => format!("{} ", metric.nerd_glyph(percent)),
             // Emoji already occupy two columns — a space on top reads as a gap.
             IconSet::Emoji => metric.emoji().to_string(),
         };
-
-        let mark = mark.map(String::from).unwrap_or_default();
-        format!("{word}{glyph}{}%{mark}", round_percent(percent))
-    }
-
-    /// Whether this tier spells the metric out in words rather than drawing it.
-    fn spells_out_the_word(self) -> bool {
-        match self {
-            IconSet::Text | IconSet::Unicode => true,
-            IconSet::NerdFont | IconSet::Emoji => false,
-        }
+        format!("{naming}{number}")
     }
 }
 
@@ -329,6 +362,27 @@ fn auto_detect(env: impl Fn(&str) -> Option<String>, has_nerd_font: impl Fn() ->
     } else {
         IconSet::Text
     }
+}
+
+// ---- one-setting config snippet -------------------------------------------------
+
+/// A paste-ready herdr `[ui]` block pinning `tier`'s naming.
+///
+/// There are two places a metric gets named on a patched build: these per-space
+/// rows, and the sidebar's whole-machine system-usage header. The header is
+/// herdr's own and reads `cpu_label` / `ram_label`, which this plugin also
+/// honours — so those keys, not the plugin's `icons`, are the single point that
+/// changes both at once. `icons` alone would leave the header saying `cpu` in
+/// words under a row of glyphs.
+///
+/// Emitting the block rather than describing it keeps the two in step without
+/// the user reverse-engineering which codepoints a tier uses. Pairing it with
+/// `icons = "text"` is deliberate: with an explicit label present the tier adds
+/// no glyph of its own (see [`IconSet::render`]), so `text` is simply the
+/// honest way to say "the labels are doing the naming now".
+pub fn herdr_ui_snippet(tier: IconSet) -> String {
+    let (cpu, ram, battery) = tier.label_values();
+    format!("[ui]\ncpu_label = \"{cpu}\"\nram_label = \"{ram}\"\nbattery_label = \"{battery}\"")
 }
 
 // ---- Nerd Font probe ------------------------------------------------------------
@@ -639,54 +693,54 @@ mod tests {
 
     #[test]
     fn text_tier_is_words_and_numbers_only() {
-        assert_eq!(IconSet::Text.cpu("cpu", 26.0), "cpu 26%");
-        assert_eq!(IconSet::Text.ram("ram", 8.0), "ram 8%");
+        assert_eq!(IconSet::Text.cpu(None, 26.0), "cpu 26%");
+        assert_eq!(IconSet::Text.ram(None, 8.0), "ram 8%");
         assert_eq!(
-            IconSet::Text.battery("bat", bat(74.0, State::Discharging)),
+            IconSet::Text.battery(None, bat(74.0, State::Discharging)),
             "bat 74%",
         );
     }
 
     #[test]
     fn unicode_tier_keeps_the_word_and_adds_a_gauge() {
-        assert_eq!(IconSet::Unicode.cpu("cpu", 26.0), "cpu ░26%");
-        assert_eq!(IconSet::Unicode.ram("ram", 8.0), "ram ░8%");
+        assert_eq!(IconSet::Unicode.cpu(None, 26.0), "cpu ░26%");
+        assert_eq!(IconSet::Unicode.ram(None, 8.0), "ram ░8%");
         assert_eq!(
-            IconSet::Unicode.battery("bat", bat(74.0, State::Discharging)),
+            IconSet::Unicode.battery(None, bat(74.0, State::Discharging)),
             "bat ▓74%",
         );
     }
 
     #[test]
     fn nerdfont_tier_replaces_the_word_with_a_glyph() {
-        assert_eq!(IconSet::NerdFont.cpu("cpu", 26.0), "\u{f4bc} 26%");
-        assert_eq!(IconSet::NerdFont.ram("ram", 8.0), "\u{efc5} 8%");
+        assert_eq!(IconSet::NerdFont.cpu(None, 26.0), "\u{f4bc} 26%");
+        assert_eq!(IconSet::NerdFont.ram(None, 8.0), "\u{efc5} 8%");
         assert_eq!(
-            IconSet::NerdFont.battery("bat", bat(74.0, State::Discharging)),
+            IconSet::NerdFont.battery(None, bat(74.0, State::Discharging)),
             "\u{f241} 74%",
         );
     }
 
     #[test]
     fn emoji_tier_sits_flush_against_the_number() {
-        assert_eq!(IconSet::Emoji.cpu("cpu", 26.0), "💻26%");
-        assert_eq!(IconSet::Emoji.ram("ram", 8.0), "🧠8%");
+        assert_eq!(IconSet::Emoji.cpu(None, 26.0), "💻26%");
+        assert_eq!(IconSet::Emoji.ram(None, 8.0), "🧠8%");
         assert_eq!(
-            IconSet::Emoji.battery("bat", bat(74.0, State::Discharging)),
+            IconSet::Emoji.battery(None, bat(74.0, State::Discharging)),
             "🔋74%",
         );
     }
 
     #[test]
     fn percentages_round_to_whole_and_survive_impossible_readings() {
-        assert_eq!(IconSet::Text.cpu("cpu", 25.4), "cpu 25%");
-        assert_eq!(IconSet::Text.cpu("cpu", 25.5), "cpu 26%");
+        assert_eq!(IconSet::Text.cpu(None, 25.4), "cpu 25%");
+        assert_eq!(IconSet::Text.cpu(None, 25.5), "cpu 26%");
         // Out of range is reported honestly rather than clamped — a CPU sum can
         // legitimately land past 100 — and must never panic.
-        assert_eq!(IconSet::Text.cpu("cpu", -3.0), "cpu -3%");
-        assert_eq!(IconSet::Unicode.cpu("cpu", 150.0), "cpu █150%");
-        assert_eq!(IconSet::Text.cpu("cpu", f64::NAN), "cpu 0%");
-        assert_eq!(IconSet::Text.cpu("cpu", 1e30), "cpu 9223372036854775807%");
+        assert_eq!(IconSet::Text.cpu(None, -3.0), "cpu -3%");
+        assert_eq!(IconSet::Unicode.cpu(None, 150.0), "cpu █150%");
+        assert_eq!(IconSet::Text.cpu(None, f64::NAN), "cpu 0%");
+        assert_eq!(IconSet::Text.cpu(None, 1e30), "cpu 9223372036854775807%");
     }
 
     // ---- charge state ----------------------------------------------------------
@@ -703,7 +757,7 @@ mod tests {
         ];
         for set in ALL_TIERS {
             for (state, mark) in expected {
-                let line = set.battery("bat", bat(74.0, state));
+                let line = set.battery(None, bat(74.0, state));
                 assert!(
                     line.ends_with(&format!("74%{mark}")),
                     "{set:?} / {state:?}: {line}",
@@ -712,11 +766,11 @@ mod tests {
         }
         // Spelled out once, so the shape of the whole line is pinned too.
         assert_eq!(
-            IconSet::Unicode.battery("bat", bat(74.0, State::Charging)),
+            IconSet::Unicode.battery(None, bat(74.0, State::Charging)),
             "bat ▓74%+",
         );
         assert_eq!(
-            IconSet::Unicode.battery("bat", bat(100.0, State::Full)),
+            IconSet::Unicode.battery(None, bat(100.0, State::Full)),
             "bat █100%=",
         );
     }
@@ -724,38 +778,93 @@ mod tests {
     // ---- herdr label overrides --------------------------------------------------
 
     #[test]
-    fn a_custom_herdr_label_wins_in_every_tier() {
-        // The `[ui]` label is the documented escape hatch, so it outranks even a
-        // glyph tier's picture — the glyph stays, the user's word leads.
+    fn a_custom_herdr_label_replaces_the_tier_glyph_in_every_tier() {
+        // An explicit `[ui]` label REPLACES the tier's naming rather than
+        // stacking on top of it. This is the property that makes herdr's
+        // `cpu_label` / `ram_label` a single source of truth: the patched
+        // sidebar's system-usage header renders from those same keys, so setting
+        // them once has to make the header and these rows agree whatever tier is
+        // active. Stacking would draw the icon twice for precisely the user who
+        // bothered to configure it.
         for set in ALL_TIERS {
-            let cpu = set.cpu("CPU", 26.0);
-            let ram = set.ram("MEM", 8.0);
-            let battery = set.battery("PWR", bat(74.0, State::Discharging));
-            assert!(cpu.starts_with("CPU "), "{set:?}: {cpu}");
-            assert!(ram.starts_with("MEM "), "{set:?}: {ram}");
-            assert!(battery.starts_with("PWR "), "{set:?}: {battery}");
-            // The word is added, not swapped in: the tier still contributes.
-            assert!(cpu.ends_with("26%"), "{set:?}: {cpu}");
+            assert_eq!(set.cpu(Some("CPU"), 26.0), "CPU 26%", "{set:?}");
+            assert_eq!(set.ram(Some("MEM"), 8.0), "MEM 8%", "{set:?}");
+            assert_eq!(
+                set.battery(Some("PWR"), bat(74.0, State::Discharging)),
+                "PWR 74%",
+                "{set:?}",
+            );
         }
-        assert_eq!(IconSet::Text.cpu("CPU", 26.0), "CPU 26%");
-        assert_eq!(IconSet::Unicode.cpu("CPU", 26.0), "CPU ░26%");
-        assert_eq!(IconSet::NerdFont.cpu("CPU", 26.0), "CPU \u{f4bc} 26%");
-        assert_eq!(IconSet::Emoji.cpu("CPU", 26.0), "CPU 💻26%");
+    }
+
+    #[test]
+    fn a_label_set_to_a_tier_glyph_is_not_doubled() {
+        // The concrete regression: someone follows `herdr_ui_snippet`, pins the
+        // Nerd Font CPU glyph into herdr's `[ui]`, and leaves the tier on
+        // nerdfont. Exactly one glyph must come out.
+        let rendered = IconSet::NerdFont.cpu(Some(&NERD_CPU.to_string()), 26.0);
+        assert_eq!(rendered.matches(NERD_CPU).count(), 1, "{rendered}");
+        assert_eq!(rendered, format!("{NERD_CPU} 26%"));
+    }
+
+    #[test]
+    fn an_empty_label_names_nothing_and_leaves_no_stray_space() {
+        // `cpu_label = ""` is a deliberate "just the number" — no word, no
+        // glyph, and critically no leading space that would misalign the row.
+        for set in ALL_TIERS {
+            let rendered = set.cpu(Some(""), 26.0);
+            assert_eq!(rendered, "26%", "{set:?}");
+        }
+    }
+
+    #[test]
+    fn the_snippet_round_trips_through_the_renderer_without_doubling() {
+        // End to end on the "one setting" promise: whatever `herdr_ui_snippet`
+        // tells the user to paste must render as exactly that naming, once, in
+        // every tier — including the tier it was generated from.
+        for source in ALL_TIERS {
+            let (cpu_label, ram_label, battery_label) = source.label_values();
+            for target in ALL_TIERS {
+                let cpu = target.cpu(Some(&cpu_label), 26.0);
+                assert_eq!(cpu, format!("{cpu_label} 26%"), "{source:?} -> {target:?}");
+                assert_eq!(target.ram(Some(&ram_label), 8.0), format!("{ram_label} 8%"));
+                assert_eq!(
+                    target.battery(Some(&battery_label), bat(74.0, State::Discharging)),
+                    format!("{battery_label} 74%"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_snippet_is_valid_toml_naming_all_three_keys() {
+        for set in ALL_TIERS {
+            let snippet = herdr_ui_snippet(set);
+            assert!(snippet.starts_with("[ui]\n"), "{set:?}: {snippet}");
+            for key in ["cpu_label", "ram_label", "battery_label"] {
+                assert!(snippet.contains(&format!("{key} = \"")), "{set:?}: {key}");
+            }
+            // One line per key plus the table header — nothing stray.
+            assert_eq!(snippet.lines().count(), 4, "{set:?}: {snippet}");
+        }
+        // The text tier reproduces the documented defaults exactly.
+        assert!(herdr_ui_snippet(IconSet::Text).contains("cpu_label = \"cpu\""));
+        assert!(herdr_ui_snippet(IconSet::Text).contains("battery_label = \"bat\""));
     }
 
     #[test]
     fn the_default_word_is_not_repeated_by_the_glyph_tiers() {
         // Handed herdr's own default, a glyph tier shows only the picture — the
         // word would be redundant with it.
-        assert_eq!(IconSet::Emoji.cpu("cpu", 26.0), "💻26%");
-        assert_eq!(IconSet::NerdFont.ram("ram", 8.0), "\u{efc5} 8%");
+        assert_eq!(IconSet::Emoji.cpu(None, 26.0), "💻26%");
+        assert_eq!(IconSet::NerdFont.ram(None, 8.0), "\u{efc5} 8%");
         assert_eq!(
-            IconSet::Emoji.battery("bat", bat(74.0, State::Discharging)),
+            IconSet::Emoji.battery(None, bat(74.0, State::Discharging)),
             "🔋74%",
         );
         // An empty label never leaves a stray leading space in any tier.
         for set in ALL_TIERS {
-            let line = set.cpu("", 26.0);
+            let line = set.cpu(Some(""), 26.0);
             assert!(!line.starts_with(' '), "{set:?}: {line:?}");
         }
     }
@@ -773,12 +882,14 @@ mod tests {
         let sweep = (0..=100).map(f64::from).chain(impossible);
         let mut out = Vec::new();
         for percent in sweep {
-            // Labels are herdr's defaults: a word the *user* supplies is their
-            // own business, and is the one thing a tier does not control.
-            out.push(set.cpu(Metric::Cpu.default_word(), percent));
-            out.push(set.ram(Metric::Ram.default_word(), percent));
+            // No herdr label, so the TIER does the naming — which is exactly
+            // what this sweep exists to inspect. A user-supplied label replaces
+            // the tier's glyph, so passing one would test their font choice
+            // rather than ours.
+            out.push(set.cpu(None, percent));
+            out.push(set.ram(None, percent));
             for state in ALL_STATES {
-                out.push(set.battery(Metric::Battery.default_word(), bat(percent, state)));
+                out.push(set.battery(None, bat(percent, state)));
             }
         }
         out

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -457,6 +457,11 @@ fn probe_nerd_font(_glyph: char) -> bool {
 /// no match, so non-empty stdout on a successful exit IS the answer. Whitespace
 /// alone does not count: a shell that echoes a bare newline must not read as a
 /// font.
+///
+/// Compiled on every target although only the Linux probe calls it, so the
+/// logic stays under test everywhere — the same reason `battery::sysfs` carries
+/// this waiver.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 fn font_list_reports_coverage(status_ok: bool, stdout: &[u8]) -> bool {
     status_ok && stdout.iter().any(|byte| !byte.is_ascii_whitespace())
 }

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -30,6 +30,7 @@
 //! The word in front of the number always comes from herdr's own `[ui]` config
 //! ([`crate::config::Labels`]) — a tier supplies the glyph, never the wording.
 
+#[cfg(target_os = "linux")]
 use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 
@@ -415,25 +416,49 @@ fn nerd_font_available() -> bool {
 
 /// Ask fontconfig whether any installed font covers `glyph`.
 ///
-/// `fc-list :charset=<hex>` prints one line per matching font and nothing at
-/// all when there is no match, so non-empty stdout IS the answer. Anything that
-/// goes wrong — no `fc-list` on `PATH`, a non-zero exit, a spawn failure — reads
-/// as "no", which falls back to [`IconSet::Text`]: the safe direction.
-///
-/// fontconfig is a Linux convention. macOS and Windows have their own font
-/// databases (CoreText, DirectWrite) and generally no `fc-list`, so `auto`
-/// yields `Text` there and those users pick a tier explicitly after running
-/// `--icons`. Querying CoreText/DirectWrite would mean real FFI against two more
-/// system APIs to sharpen a heuristic that still could not see the terminal's
-/// actual font — not worth it.
+/// **Linux only, on purpose.** fontconfig is a Linux convention; macOS and
+/// Windows keep their fonts in CoreText and DirectWrite. Where `fc-list` is
+/// absent this would always answer "no", which is harmless — but where it is
+/// present *and behaves differently* it is worse than useless. A macOS CI runner
+/// with Homebrew fontconfig reported coverage for `U+10FFFE`, a permanent
+/// noncharacter no font can contain; trusting that would have auto-selected a
+/// Nerd Font tier on machines with no Nerd Font, which is exactly the row of
+/// boxes `auto` exists to avoid. So the probe is scoped to the one platform
+/// whose answer has been verified, and everywhere else `auto` yields
+/// [`IconSet::Text`] — matching what the README promises.
+#[cfg(target_os = "linux")]
 fn probe_nerd_font(glyph: char) -> bool {
-    Command::new("fc-list")
+    let output = Command::new("fc-list")
         .arg(format!(":charset={:x}", glyph as u32))
         .arg("family")
         .stdin(Stdio::null())
         .stderr(Stdio::null())
-        .output()
-        .is_ok_and(|out| out.status.success() && !out.stdout.is_empty())
+        .output();
+    match output {
+        Ok(out) => font_list_reports_coverage(out.status.success(), &out.stdout),
+        // No `fc-list` on PATH, or the spawn failed: read as "no", which falls
+        // back to Text — the safe direction.
+        Err(_) => false,
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn probe_nerd_font(_glyph: char) -> bool {
+    false
+}
+
+/// Decide coverage from an `fc-list` result.
+///
+/// Split from the spawn so the decision is testable without a subprocess — the
+/// version that called `fc-list` inside its own test was passing on Linux and
+/// failing on macOS for reasons that had nothing to do with the logic.
+///
+/// `fc-list` prints one line per matching font and nothing at all when there is
+/// no match, so non-empty stdout on a successful exit IS the answer. Whitespace
+/// alone does not count: a shell that echoes a bare newline must not read as a
+/// font.
+fn font_list_reports_coverage(status_ok: bool, stdout: &[u8]) -> bool {
+    status_ok && stdout.iter().any(|byte| !byte.is_ascii_whitespace())
 }
 
 /// Whether `locale` names a UTF-8 charset (`en_US.UTF-8`, `en_US.utf8`, …).
@@ -602,13 +627,40 @@ mod tests {
     }
 
     #[test]
-    fn probing_for_an_absent_glyph_is_false_and_never_panics() {
-        // U+10FFFE is a permanent noncharacter, so no font can claim it. This
-        // also exercises the real `fc-list` path: on a host without fontconfig
-        // the spawn simply fails, which must read as "no" rather than blowing
-        // up. Either way the answer is false, so the test is deterministic
-        // across Linux, macOS, and Windows CI runners.
-        assert!(!probe_nerd_font('\u{10FFFE}'));
+    fn font_list_output_decides_coverage() {
+        // The decision, without a subprocess. `fc-list` prints one line per
+        // match and nothing at all otherwise.
+        assert!(font_list_reports_coverage(true, b"DejaVu Sans Mono\n"));
+        assert!(!font_list_reports_coverage(true, b""));
+        // Whitespace alone is not a font.
+        assert!(!font_list_reports_coverage(true, b"\n"));
+        assert!(!font_list_reports_coverage(true, b"  \t\n"));
+        // A non-zero exit is never coverage, whatever it printed.
+        assert!(!font_list_reports_coverage(false, b"DejaVu Sans Mono\n"));
+    }
+
+    #[test]
+    fn the_probe_runs_without_panicking_whatever_the_host_has() {
+        // Deliberately asserts nothing about the ANSWER: it depends on the
+        // host's fonts, and an earlier version of this test asserted that a
+        // noncharacter is uncovered, which held on Linux and failed on a macOS
+        // runner whose fontconfig claimed otherwise. The logic is pinned by
+        // `font_list_output_decides_coverage`; this only pins that spawning is
+        // safe — including where `fc-list` does not exist.
+        let _ = probe_nerd_font(NERD_CPU);
+        let _ = probe_nerd_font('\u{10FFFE}');
+    }
+
+    #[test]
+    #[cfg(not(target_os = "linux"))]
+    fn off_linux_the_probe_is_always_false() {
+        // The README promises `auto` yields Text off Linux; this is that promise
+        // in code, checked on the macOS and Windows CI runners.
+        assert!(!probe_nerd_font(NERD_CPU));
+        assert_eq!(
+            auto_detect(env_from(&[("LANG", "en_US.UTF-8")]), nerd_font_available),
+            IconSet::Text,
+        );
     }
 
     #[test]

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -1,0 +1,732 @@
+//! Icon tiers — the glyph vocabulary a metric is rendered with.
+//!
+//! The sidebar row is only a few characters wide, so every glyph has to earn its
+//! column. Four tiers ladder up by how much they assume about the user's font:
+//!
+//! | tier | cpu | ram | battery | needs |
+//! |---|---|---|---|---|
+//! | [`IconSet::Text`] | `cpu 26%` | `ram 8%` | `bat 74%` | nothing |
+//! | [`IconSet::Unicode`] | `cpu ░26%` | `ram ░8%` | `bat ▓74%` | nothing |
+//! | [`IconSet::NerdFont`] | ` 26%` | ` 8%` | ` 74%` | a Nerd Font |
+//! | [`IconSet::Emoji`] | `💻26%` | `🧠8%` | `🔋74%` | a colour emoji font |
+//!
+//! Only the first two are safe unprompted, and that claim is measured rather
+//! than assumed: every glyph they emit was checked with `fc-list :charset=<cp>`
+//! against the default mono faces (DejaVu Sans Mono, Liberation Mono) and is
+//! present in both. Glyphs that are present in only *one* of them — `▣ ▤ ▮ ▯ ▰
+//! ▱ ⚡` — are deliberately unused, and emoji are missing from both *and*
+//! double-width, which shears a narrow sidebar. The `safe_tiers_*` test enforces
+//! that contract against real rendered output, so it cannot rot.
+//!
+//! The word in front of the number always comes from herdr's own `[ui]` config
+//! ([`crate::config::Labels`]) — a tier supplies the glyph, never the wording.
+
+use crate::battery::{Battery, State};
+use crate::config::non_empty_env;
+
+/// Which glyph vocabulary to render metrics with.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IconSet {
+    /// Plain words — always renders, never needs a font.
+    Text,
+    /// BMP block glyphs verified present in the default mono fonts of all three
+    /// platforms. No font install required.
+    Unicode,
+    /// Nerd Font private-use glyphs. Requires a Nerd Font.
+    NerdFont,
+    /// Emoji pictograms. Requires a colour emoji font.
+    Emoji,
+}
+
+// ---- glyph tables (the single source of truth) -------------------------------
+
+/// Level gauge for the [`IconSet::Unicode`] tier, low step first.
+///
+/// `(exclusive upper bound, glyph)`, scanned in order. The closing
+/// `f64::INFINITY` row makes the table total, so no reading — including one past
+/// 100 — can fall off the end.
+const GAUGE_RAMP: [(f64, char); 4] = [
+    (34.0, '░'),          // U+2591 light shade
+    (67.0, '▒'),          // U+2592 medium shade
+    (90.0, '▓'),          // U+2593 dark shade
+    (f64::INFINITY, '█'), // U+2588 full block
+];
+
+/// Nerd Font battery family (`nf-fa-battery_*`), low step first.
+const NERD_BATTERY_RAMP: [(f64, char); 5] = [
+    (15.0, '\u{f244}'),          // U+F244 empty
+    (40.0, '\u{f243}'),          // U+F243 quarter
+    (65.0, '\u{f242}'),          // U+F242 half
+    (90.0, '\u{f241}'),          // U+F241 three quarters
+    (f64::INFINITY, '\u{f240}'), // U+F240 full
+];
+
+/// U+F4BC `nf-oct-cpu`.
+const NERD_CPU: char = '\u{f4bc}';
+/// U+EFC5 `nf-md-memory`.
+const NERD_RAM: char = '\u{efc5}';
+
+/// U+1F4BB personal computer.
+const EMOJI_CPU: char = '💻';
+/// U+1F9E0 brain.
+const EMOJI_RAM: char = '🧠';
+/// U+1F50B battery.
+const EMOJI_BATTERY: char = '🔋';
+
+/// Charge is climbing.
+const MARK_CHARGING: char = '+';
+/// On power but not climbing — topped off, or held down by a charge limit.
+const MARK_STEADY: char = '=';
+
+// ---- charge state -------------------------------------------------------------
+
+/// Charge-direction suffix for a battery reading, or `None` when the state says
+/// nothing worth a column.
+///
+/// Deliberately ASCII and shared by all four tiers. Switching tier should change
+/// the *pictures*, not the meaning of the line, and a mark that every font on
+/// earth can draw can never break the font-safety contract of the safe tiers.
+///
+/// | state | mark | reads as |
+/// |---|---|---|
+/// | `Charging` | `+` | going up |
+/// | `Full`, `NotCharging` | `=` | on power, holding |
+/// | `Discharging`, `Unknown` | none | the number is the whole story |
+///
+/// The match is exhaustive on purpose: a new [`State`] variant must fail the
+/// build here rather than silently inherit a blank mark.
+fn charge_mark(state: State) -> Option<char> {
+    match state {
+        State::Charging => Some(MARK_CHARGING),
+        // `Full` is topped off; `NotCharging` is a plugged-in battery a vendor
+        // charge limit is holding below full. Both mean "on power, not moving".
+        State::Full | State::NotCharging => Some(MARK_STEADY),
+        // Discharging is the common case, so it gets the narrowest rendering.
+        State::Discharging | State::Unknown => None,
+    }
+}
+
+// ---- metrics ------------------------------------------------------------------
+
+/// The metrics a tier can draw. Private — callers go through the [`IconSet`]
+/// methods, which is what keeps the glyph tables from leaking into the wiring.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Metric {
+    Cpu,
+    Ram,
+    Battery,
+}
+
+impl Metric {
+    /// The word herdr's `[ui]` config yields for this metric when the user has
+    /// set no override.
+    ///
+    /// Mirrors [`crate::config::Labels`]'s defaults. It exists so we can tell "the
+    /// user typed this word" from "this is just the default we were handed",
+    /// which is what lets an explicit label win even in the glyph tiers — see
+    /// [`IconSet::render`].
+    fn default_word(self) -> &'static str {
+        match self {
+            Metric::Cpu => "cpu",
+            Metric::Ram => "ram",
+            Metric::Battery => "bat",
+        }
+    }
+
+    /// Nerd Font glyph. Battery is the only metric whose picture tracks the
+    /// reading, so it ramps like the gauge does.
+    fn nerd_glyph(self, percent: f64) -> char {
+        match self {
+            Metric::Cpu => NERD_CPU,
+            Metric::Ram => NERD_RAM,
+            Metric::Battery => ramp_pick(&NERD_BATTERY_RAMP, percent),
+        }
+    }
+
+    fn emoji(self) -> char {
+        match self {
+            Metric::Cpu => EMOJI_CPU,
+            Metric::Ram => EMOJI_RAM,
+            Metric::Battery => EMOJI_BATTERY,
+        }
+    }
+}
+
+// ---- rendering ----------------------------------------------------------------
+
+impl IconSet {
+    /// Render CPU load — `cpu ░26%` in the [`IconSet::Unicode`] tier.
+    pub fn cpu(self, label: &str, percent: f64) -> String {
+        self.render(Metric::Cpu, label, percent, None)
+    }
+
+    /// Render RAM use — `ram ░8%` in the [`IconSet::Unicode`] tier.
+    pub fn ram(self, label: &str, percent: f64) -> String {
+        self.render(Metric::Ram, label, percent, None)
+    }
+
+    /// Render a battery reading — `bat ▓74%+` for 74% and charging in the
+    /// [`IconSet::Unicode`] tier.
+    pub fn battery(self, label: &str, reading: Battery) -> String {
+        self.render(
+            Metric::Battery,
+            label,
+            reading.percent,
+            charge_mark(reading.state),
+        )
+    }
+
+    /// `[word ][glyph]<n>%[mark]` — the one assembly every tier and metric goes
+    /// through, so the tiers cannot drift apart in spacing or ordering.
+    fn render(self, metric: Metric, label: &str, percent: f64, mark: Option<char>) -> String {
+        // The glyph tiers put a picture where the word would go, so they print a
+        // word only when the user actually chose one (herdr `[ui]` beats the
+        // tier — the config escape hatch has to keep working at every setting).
+        // Text and Unicode always carry it: there, the word is the only thing
+        // naming the number.
+        let names_metric = self.spells_out_the_word() || label != metric.default_word();
+        let word = if names_metric && !label.is_empty() {
+            format!("{label} ")
+        } else {
+            String::new() // an empty label must not leave a stray leading space
+        };
+
+        let glyph = match self {
+            IconSet::Text => String::new(),
+            // The gauge runs straight into the number it is measuring.
+            IconSet::Unicode => ramp_pick(&GAUGE_RAMP, percent).to_string(),
+            // Nerd Font glyphs are drawn edge-to-edge in their cell; without the
+            // space the digits touch them.
+            IconSet::NerdFont => format!("{} ", metric.nerd_glyph(percent)),
+            // Emoji already occupy two columns — a space on top reads as a gap.
+            IconSet::Emoji => metric.emoji().to_string(),
+        };
+
+        let mark = mark.map(String::from).unwrap_or_default();
+        format!("{word}{glyph}{}%{mark}", round_percent(percent))
+    }
+
+    /// Whether this tier spells the metric out in words rather than drawing it.
+    fn spells_out_the_word(self) -> bool {
+        match self {
+            IconSet::Text | IconSet::Unicode => true,
+            IconSet::NerdFont | IconSet::Emoji => false,
+        }
+    }
+}
+
+/// The first glyph in `ramp` whose exclusive upper bound is above `percent`.
+///
+/// Shared by the Unicode gauge and the Nerd Font battery family so there is one
+/// ramp rule instead of two. Both tables close with `f64::INFINITY`, so every
+/// finite reading matches — negative and past-100 included.
+///
+/// The two non-finite readings are handled deliberately rather than by accident,
+/// because both compare false against every bound and would otherwise land on
+/// whichever step the fallback happened to pick: `NaN` becomes the lowest step
+/// (a reading we could not make sense of is not a full one) and `+INFINITY` the
+/// highest.
+fn ramp_pick(ramp: &[(f64, char)], percent: f64) -> char {
+    let percent = if percent.is_nan() {
+        f64::NEG_INFINITY
+    } else {
+        percent
+    };
+    ramp.iter()
+        .find(|&&(upper, _)| percent < upper)
+        .or_else(|| ramp.last())
+        .map_or(' ', |&(_, glyph)| glyph) // unreachable: both tables are non-empty
+}
+
+/// Percentage rounded to whole for display, matching the rounding the daemon
+/// already applies to the sidebar row.
+///
+/// A float-to-int cast saturates rather than wrapping and turns `NaN` into `0`,
+/// so no reading can panic here.
+fn round_percent(percent: f64) -> i64 {
+    percent.round() as i64
+}
+
+// ---- tier resolution ------------------------------------------------------------
+
+/// Locale variables in POSIX precedence order, highest first.
+const LOCALE_VARS: [&str; 3] = ["LC_ALL", "LC_CTYPE", "LANG"];
+
+/// Pick the tier named by the plugin config, auto-detecting when it says nothing
+/// useful.
+///
+/// Accepts `text`, `unicode`, `nerdfont`, `emoji` and `auto`, ignoring case and
+/// any `-`/`_` separators (so `Nerd-Font` works). Anything else — including a
+/// missing key — auto-detects instead of erroring: a typo in a cosmetic setting
+/// must not blank the sidebar.
+pub fn resolve(configured: Option<&str>) -> IconSet {
+    resolve_with(configured, non_empty_env)
+}
+
+/// [`resolve`] with the environment injected.
+///
+/// The seam exists for the tests: mutating the real process environment to
+/// exercise locale precedence would race every other test thread in the binary.
+fn resolve_with(configured: Option<&str>, env: impl Fn(&str) -> Option<String>) -> IconSet {
+    match configured.map(normalise_tier_name).as_deref() {
+        Some("text") => IconSet::Text,
+        Some("unicode") => IconSet::Unicode,
+        Some("nerdfont") => IconSet::NerdFont,
+        Some("emoji") => IconSet::Emoji,
+        _ => auto_detect(env),
+    }
+}
+
+/// Fold a configured tier name to its canonical spelling.
+fn normalise_tier_name(name: &str) -> String {
+    name.trim().to_ascii_lowercase().replace(['-', '_'], "")
+}
+
+/// The best tier that needs no font install: [`IconSet::Unicode`] on a UTF-8
+/// locale, else [`IconSet::Text`].
+///
+/// A non-UTF-8 locale is the one signal we can read locally that block glyphs
+/// will not survive the trip to the terminal, and it costs nothing to honour.
+/// Font *coverage* is not detectable from here at all, which is why the Unicode
+/// tier is restricted to glyphs measured to be in the stock faces.
+fn auto_detect(env: impl Fn(&str) -> Option<String>) -> IconSet {
+    // `non_empty_env` treats an empty value as unset, which is also what POSIX
+    // says about an empty `LC_ALL` — so an empty higher-precedence variable
+    // correctly falls through to the next one.
+    let locale = LOCALE_VARS.iter().find_map(|name| env(name));
+    if is_utf8_locale(locale.as_deref()) {
+        IconSet::Unicode
+    } else {
+        IconSet::Text
+    }
+}
+
+/// Whether `locale` names a UTF-8 charset (`en_US.UTF-8`, `en_US.utf8`, …).
+fn is_utf8_locale(locale: Option<&str>) -> bool {
+    let Some(locale) = locale else {
+        return false; // no locale at all: assume the narrowest terminal
+    };
+    let lower = locale.to_ascii_lowercase();
+    lower.contains("utf-8") || lower.contains("utf8")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every tier, so a new one cannot quietly skip the sweeps below.
+    const ALL_TIERS: [IconSet; 4] = [
+        IconSet::Text,
+        IconSet::Unicode,
+        IconSet::NerdFont,
+        IconSet::Emoji,
+    ];
+
+    /// Every charge state.
+    const ALL_STATES: [State; 5] = [
+        State::Charging,
+        State::Discharging,
+        State::Full,
+        State::NotCharging,
+        State::Unknown,
+    ];
+
+    fn bat(percent: f64, state: State) -> Battery {
+        Battery { percent, state }
+    }
+
+    /// Environment lookup backed by a fixed table, mirroring `non_empty_env`'s
+    /// rule that an empty value counts as unset.
+    fn env_from<'a>(pairs: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |name| {
+            pairs
+                .iter()
+                .find(|(key, _)| *key == name)
+                .map(|(_, value)| value.to_string())
+                .filter(|value| !value.is_empty())
+        }
+    }
+
+    /// Resolve with no environment at all — isolates config parsing from locale.
+    fn resolve_bare(configured: Option<&str>) -> IconSet {
+        resolve_with(configured, env_from(&[]))
+    }
+
+    // ---- tier parsing --------------------------------------------------------
+
+    #[test]
+    fn every_tier_name_parses_to_its_tier() {
+        assert_eq!(resolve_bare(Some("text")), IconSet::Text);
+        assert_eq!(resolve_bare(Some("unicode")), IconSet::Unicode);
+        assert_eq!(resolve_bare(Some("nerdfont")), IconSet::NerdFont);
+        assert_eq!(resolve_bare(Some("emoji")), IconSet::Emoji);
+    }
+
+    #[test]
+    fn tier_names_ignore_case_whitespace_and_separators() {
+        assert_eq!(resolve_bare(Some("  Unicode ")), IconSet::Unicode);
+        assert_eq!(resolve_bare(Some("EMOJI")), IconSet::Emoji);
+        assert_eq!(resolve_bare(Some("Nerd-Font")), IconSet::NerdFont);
+        assert_eq!(resolve_bare(Some("nerd_font")), IconSet::NerdFont);
+    }
+
+    #[test]
+    fn auto_unknown_and_missing_all_fall_back_to_detection() {
+        // The bare environment detects `Text`; a UTF-8 one detects `Unicode`.
+        // Both must follow the *detector*, not a hardcoded default.
+        let utf8 = || env_from(&[("LANG", "en_US.UTF-8")]);
+        for configured in [None, Some("auto"), Some("bogus"), Some("")] {
+            assert_eq!(resolve_bare(configured), IconSet::Text, "{configured:?}");
+            assert_eq!(
+                resolve_with(configured, utf8()),
+                IconSet::Unicode,
+                "{configured:?}",
+            );
+        }
+    }
+
+    // ---- locale auto-detection -----------------------------------------------
+
+    #[test]
+    fn auto_detect_prefers_lc_all_then_lc_ctype_then_lang() {
+        // Highest-precedence variable wins even when it disagrees with the rest.
+        let all_wins = env_from(&[
+            ("LC_ALL", "C"),
+            ("LC_CTYPE", "en_US.UTF-8"),
+            ("LANG", "en_US.UTF-8"),
+        ]);
+        assert_eq!(auto_detect(all_wins), IconSet::Text);
+
+        let ctype_wins = env_from(&[("LC_CTYPE", "C"), ("LANG", "en_US.UTF-8")]);
+        assert_eq!(auto_detect(ctype_wins), IconSet::Text);
+
+        // An empty higher-precedence variable is unset, so the next one decides.
+        let empty_falls_through = env_from(&[("LC_ALL", ""), ("LANG", "en_US.UTF-8")]);
+        assert_eq!(auto_detect(empty_falls_through), IconSet::Unicode);
+
+        let lang_only = env_from(&[("LANG", "en_US.UTF-8")]);
+        assert_eq!(auto_detect(lang_only), IconSet::Unicode);
+    }
+
+    #[test]
+    fn utf8_is_recognised_however_it_is_spelled() {
+        assert!(is_utf8_locale(Some("en_US.UTF-8")));
+        assert!(is_utf8_locale(Some("en_US.utf8")));
+        assert!(is_utf8_locale(Some("C.UTF-8")));
+        assert!(is_utf8_locale(Some("de_DE.Utf-8")));
+        assert!(is_utf8_locale(Some("ja_JP.UTF8")));
+    }
+
+    #[test]
+    fn non_utf8_locales_fall_back_to_text() {
+        for locale in ["C", "POSIX", "en_US", "en_US.ISO-8859-1", ""] {
+            assert_eq!(
+                auto_detect(env_from(&[("LANG", locale)])),
+                IconSet::Text,
+                "{locale:?}",
+            );
+        }
+        // Nothing set at all is also Text.
+        assert_eq!(auto_detect(env_from(&[])), IconSet::Text);
+        assert!(!is_utf8_locale(None));
+    }
+
+    // ---- the level gauge ------------------------------------------------------
+
+    #[test]
+    fn gauge_ramp_steps_on_its_documented_boundaries() {
+        let gauge = |p: f64| ramp_pick(&GAUGE_RAMP, p);
+        assert_eq!(gauge(0.0), '░');
+        assert_eq!(gauge(33.0), '░');
+        assert_eq!(gauge(33.9), '░');
+        assert_eq!(gauge(34.0), '▒');
+        assert_eq!(gauge(66.0), '▒');
+        assert_eq!(gauge(67.0), '▓');
+        assert_eq!(gauge(89.0), '▓');
+        assert_eq!(gauge(90.0), '█');
+        assert_eq!(gauge(100.0), '█');
+    }
+
+    #[test]
+    fn gauge_ramp_is_total_for_impossible_readings() {
+        // Out of range in both directions and NaN: a glyph, never a panic and
+        // never an out-of-bounds step.
+        assert_eq!(ramp_pick(&GAUGE_RAMP, -1.0), '░');
+        assert_eq!(ramp_pick(&GAUGE_RAMP, -1e30), '░');
+        assert_eq!(ramp_pick(&GAUGE_RAMP, 101.0), '█');
+        assert_eq!(ramp_pick(&GAUGE_RAMP, f64::INFINITY), '█');
+        assert_eq!(ramp_pick(&GAUGE_RAMP, f64::NEG_INFINITY), '░');
+        // An unreadable percentage shows as the lowest step, not a full one.
+        assert_eq!(ramp_pick(&GAUGE_RAMP, f64::NAN), '░');
+    }
+
+    #[test]
+    fn ramp_tables_are_ordered_and_total() {
+        // `ramp_pick` scans in order, so a table whose bounds are not ascending
+        // would silently shadow steps; the closing INFINITY is what makes every
+        // finite reading match.
+        for ramp in [&GAUGE_RAMP[..], &NERD_BATTERY_RAMP[..]] {
+            for pair in ramp.windows(2) {
+                assert!(pair[0].0 < pair[1].0, "bounds must ascend: {pair:?}");
+            }
+            assert_eq!(ramp.last().expect("non-empty").0, f64::INFINITY);
+        }
+    }
+
+    #[test]
+    fn nerd_battery_glyph_tracks_the_charge_level() {
+        let glyph = |p: f64| Metric::Battery.nerd_glyph(p);
+        assert_eq!(glyph(0.0), '\u{f244}'); // empty
+        assert_eq!(glyph(14.9), '\u{f244}');
+        assert_eq!(glyph(15.0), '\u{f243}'); // quarter
+        assert_eq!(glyph(40.0), '\u{f242}'); // half
+        assert_eq!(glyph(65.0), '\u{f241}'); // three quarters
+        assert_eq!(glyph(74.0), '\u{f241}');
+        assert_eq!(glyph(90.0), '\u{f240}'); // full
+        assert_eq!(glyph(100.0), '\u{f240}');
+    }
+
+    // ---- rendering, tier by tier ----------------------------------------------
+
+    #[test]
+    fn text_tier_is_words_and_numbers_only() {
+        assert_eq!(IconSet::Text.cpu("cpu", 26.0), "cpu 26%");
+        assert_eq!(IconSet::Text.ram("ram", 8.0), "ram 8%");
+        assert_eq!(
+            IconSet::Text.battery("bat", bat(74.0, State::Discharging)),
+            "bat 74%",
+        );
+    }
+
+    #[test]
+    fn unicode_tier_keeps_the_word_and_adds_a_gauge() {
+        assert_eq!(IconSet::Unicode.cpu("cpu", 26.0), "cpu ░26%");
+        assert_eq!(IconSet::Unicode.ram("ram", 8.0), "ram ░8%");
+        assert_eq!(
+            IconSet::Unicode.battery("bat", bat(74.0, State::Discharging)),
+            "bat ▓74%",
+        );
+    }
+
+    #[test]
+    fn nerdfont_tier_replaces_the_word_with_a_glyph() {
+        assert_eq!(IconSet::NerdFont.cpu("cpu", 26.0), "\u{f4bc} 26%");
+        assert_eq!(IconSet::NerdFont.ram("ram", 8.0), "\u{efc5} 8%");
+        assert_eq!(
+            IconSet::NerdFont.battery("bat", bat(74.0, State::Discharging)),
+            "\u{f241} 74%",
+        );
+    }
+
+    #[test]
+    fn emoji_tier_sits_flush_against_the_number() {
+        assert_eq!(IconSet::Emoji.cpu("cpu", 26.0), "💻26%");
+        assert_eq!(IconSet::Emoji.ram("ram", 8.0), "🧠8%");
+        assert_eq!(
+            IconSet::Emoji.battery("bat", bat(74.0, State::Discharging)),
+            "🔋74%",
+        );
+    }
+
+    #[test]
+    fn percentages_round_to_whole_and_survive_impossible_readings() {
+        assert_eq!(IconSet::Text.cpu("cpu", 25.4), "cpu 25%");
+        assert_eq!(IconSet::Text.cpu("cpu", 25.5), "cpu 26%");
+        // Out of range is reported honestly rather than clamped — a CPU sum can
+        // legitimately land past 100 — and must never panic.
+        assert_eq!(IconSet::Text.cpu("cpu", -3.0), "cpu -3%");
+        assert_eq!(IconSet::Unicode.cpu("cpu", 150.0), "cpu █150%");
+        assert_eq!(IconSet::Text.cpu("cpu", f64::NAN), "cpu 0%");
+        assert_eq!(IconSet::Text.cpu("cpu", 1e30), "cpu 9223372036854775807%");
+    }
+
+    // ---- charge state ----------------------------------------------------------
+
+    #[test]
+    fn every_tier_renders_every_charge_state() {
+        // Marks are tier-independent by design, so the expectation is one table.
+        let expected = [
+            (State::Charging, "+"),
+            (State::Full, "="),
+            (State::NotCharging, "="),
+            (State::Discharging, ""),
+            (State::Unknown, ""),
+        ];
+        for set in ALL_TIERS {
+            for (state, mark) in expected {
+                let line = set.battery("bat", bat(74.0, state));
+                assert!(
+                    line.ends_with(&format!("74%{mark}")),
+                    "{set:?} / {state:?}: {line}",
+                );
+            }
+        }
+        // Spelled out once, so the shape of the whole line is pinned too.
+        assert_eq!(
+            IconSet::Unicode.battery("bat", bat(74.0, State::Charging)),
+            "bat ▓74%+",
+        );
+        assert_eq!(
+            IconSet::Unicode.battery("bat", bat(100.0, State::Full)),
+            "bat █100%=",
+        );
+    }
+
+    // ---- herdr label overrides --------------------------------------------------
+
+    #[test]
+    fn a_custom_herdr_label_wins_in_every_tier() {
+        // The `[ui]` label is the documented escape hatch, so it outranks even a
+        // glyph tier's picture — the glyph stays, the user's word leads.
+        for set in ALL_TIERS {
+            let cpu = set.cpu("CPU", 26.0);
+            let ram = set.ram("MEM", 8.0);
+            let battery = set.battery("PWR", bat(74.0, State::Discharging));
+            assert!(cpu.starts_with("CPU "), "{set:?}: {cpu}");
+            assert!(ram.starts_with("MEM "), "{set:?}: {ram}");
+            assert!(battery.starts_with("PWR "), "{set:?}: {battery}");
+            // The word is added, not swapped in: the tier still contributes.
+            assert!(cpu.ends_with("26%"), "{set:?}: {cpu}");
+        }
+        assert_eq!(IconSet::Text.cpu("CPU", 26.0), "CPU 26%");
+        assert_eq!(IconSet::Unicode.cpu("CPU", 26.0), "CPU ░26%");
+        assert_eq!(IconSet::NerdFont.cpu("CPU", 26.0), "CPU \u{f4bc} 26%");
+        assert_eq!(IconSet::Emoji.cpu("CPU", 26.0), "CPU 💻26%");
+    }
+
+    #[test]
+    fn the_default_word_is_not_repeated_by_the_glyph_tiers() {
+        // Handed herdr's own default, a glyph tier shows only the picture — the
+        // word would be redundant with it.
+        assert_eq!(IconSet::Emoji.cpu("cpu", 26.0), "💻26%");
+        assert_eq!(IconSet::NerdFont.ram("ram", 8.0), "\u{efc5} 8%");
+        assert_eq!(
+            IconSet::Emoji.battery("bat", bat(74.0, State::Discharging)),
+            "🔋74%",
+        );
+        // An empty label never leaves a stray leading space in any tier.
+        for set in ALL_TIERS {
+            let line = set.cpu("", 26.0);
+            assert!(!line.starts_with(' '), "{set:?}: {line:?}");
+        }
+    }
+
+    // ---- font safety: the "renders without installing a font" contract -----------
+
+    /// Every string a tier can produce: all three metrics, every charge state,
+    /// every step of both ramps, and the awkward readings around them.
+    ///
+    /// The font-safety test walks this *output* rather than a hand-kept list of
+    /// glyphs, so a glyph added anywhere in a tier is covered the moment it is
+    /// added — the guard cannot drift from the implementation.
+    fn every_rendering(set: IconSet) -> Vec<String> {
+        let impossible = [-1.0, -1e30, 100.5, 150.0, f64::NAN, f64::INFINITY];
+        let sweep = (0..=100).map(f64::from).chain(impossible);
+        let mut out = Vec::new();
+        for percent in sweep {
+            // Labels are herdr's defaults: a word the *user* supplies is their
+            // own business, and is the one thing a tier does not control.
+            out.push(set.cpu(Metric::Cpu.default_word(), percent));
+            out.push(set.ram(Metric::Ram.default_word(), percent));
+            for state in ALL_STATES {
+                out.push(set.battery(Metric::Battery.default_word(), bat(percent, state)));
+            }
+        }
+        out
+    }
+
+    /// Private Use Area — glyphs here mean nothing without the matching font.
+    fn is_private_use(c: char) -> bool {
+        (0xE000..=0xF8FF).contains(&(c as u32))
+    }
+
+    /// The non-ASCII glyphs measured to be present in *both* default mono faces
+    /// (DejaVu Sans Mono and Liberation Mono), via `fc-list :charset=<cp>`.
+    ///
+    /// BMP-and-not-private-use is necessary but not sufficient: `⚡` U+26A1 and
+    /// `▮ ▯ ▰ ▱ ▣ ▤` all clear that bar yet ship in only one of the two faces, so
+    /// they render as a box for half of Linux users. Only what is on this list
+    /// has actually been measured, so only what is on this list may appear in a
+    /// safe tier. Extending it means re-running the `fc-list` check first.
+    const VERIFIED_MONO_GLYPHS: [char; 11] =
+        ['■', '□', '●', '○', '█', '░', '▒', '▓', '·', '│', '┼'];
+
+    #[test]
+    fn safe_tiers_emit_only_bmp_non_private_use_glyphs() {
+        // THIS IS THE CONTRACT: `Text` and `Unicode` must render on a stock
+        // system with no font installed. Anything outside the BMP is emoji or
+        // astral territory (missing from the default mono faces, and
+        // double-width, which shears the sidebar); anything in the Private Use
+        // Area is a Nerd Font glyph that draws as a blank box.
+        //
+        // If this test fails, the glyph you just added is not safe — put it in
+        // the `NerdFont` or `Emoji` tier instead of loosening the assert.
+        for set in [IconSet::Text, IconSet::Unicode] {
+            for line in every_rendering(set) {
+                for c in line.chars() {
+                    assert!(
+                        (c as u32) <= 0xFFFF,
+                        "{set:?} emits non-BMP U+{:04X} in {line:?}",
+                        c as u32,
+                    );
+                    assert!(
+                        !is_private_use(c),
+                        "{set:?} emits private-use U+{:04X} in {line:?}",
+                        c as u32,
+                    );
+                    assert!(
+                        c.is_ascii() || VERIFIED_MONO_GLYPHS.contains(&c),
+                        "{set:?} emits unmeasured glyph {c} (U+{:04X}) in {line:?} \
+                         — only glyphs checked against both default mono faces \
+                         belong in a safe tier",
+                        c as u32,
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn safe_tier_glyph_tables_are_safe_at_the_source() {
+        // The sweep above proves the rendered output is safe; this pins the
+        // tables it draws from, so a glyph that is added but not yet reachable
+        // is still caught.
+        let safe_glyphs = GAUGE_RAMP
+            .iter()
+            .map(|&(_, glyph)| glyph)
+            .chain([MARK_CHARGING, MARK_STEADY]);
+        for c in safe_glyphs {
+            assert!((c as u32) <= 0xFFFF, "U+{:04X} is not BMP", c as u32);
+            assert!(!is_private_use(c), "U+{:04X} is private use", c as u32);
+            assert!(
+                c.is_ascii() || VERIFIED_MONO_GLYPHS.contains(&c),
+                "U+{:04X} has not been measured against the default mono faces",
+                c as u32,
+            );
+        }
+    }
+
+    #[test]
+    fn opt_in_tiers_are_out_of_the_safe_range_by_construction() {
+        // Documents *why* these two tiers are opt-in rather than auto-detected:
+        // by definition their glyphs cannot be there without a font install.
+        for glyph in [NERD_CPU, NERD_RAM]
+            .into_iter()
+            .chain(NERD_BATTERY_RAMP.iter().map(|&(_, glyph)| glyph))
+        {
+            assert!(
+                is_private_use(glyph),
+                "Nerd Font glyph U+{:04X} is outside the PUA — is it really a \
+                 Nerd Font codepoint?",
+                glyph as u32,
+            );
+        }
+        for glyph in [EMOJI_CPU, EMOJI_RAM, EMOJI_BATTERY] {
+            assert!(
+                (glyph as u32) > 0xFFFF,
+                "emoji U+{:04X} is inside the BMP",
+                glyph as u32,
+            );
+        }
+    }
+}

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -18,8 +18,20 @@
 //! double-width, which shears a narrow sidebar. The `safe_tiers_*` test enforces
 //! that contract against real rendered output, so it cannot rot.
 //!
+//! [`resolve`] picks the tier. Its `auto` mode chooses between exactly two of
+//! them — [`IconSet::NerdFont`] when a Nerd Font is detected, else
+//! [`IconSet::Text`]. It deliberately never selects [`IconSet::Unicode`]: those
+//! glyphs are *present* everywhere, but `░`/`▒` are dither patterns that render
+//! as an indistinct blob at terminal sizes. Being in the font and being legible
+//! are different properties, and only the first one is measurable from here.
+//! See [`auto_detect`] and [`nerd_font_available`] for what the detection can
+//! and cannot know.
+//!
 //! The word in front of the number always comes from herdr's own `[ui]` config
 //! ([`crate::config::Labels`]) — a tier supplies the glyph, never the wording.
+
+use std::process::{Command, Stdio};
+use std::sync::OnceLock;
 
 use crate::battery::{Battery, State};
 use crate::config::non_empty_env;
@@ -260,20 +272,27 @@ const LOCALE_VARS: [&str; 3] = ["LC_ALL", "LC_CTYPE", "LANG"];
 /// missing key — auto-detects instead of erroring: a typo in a cosmetic setting
 /// must not blank the sidebar.
 pub fn resolve(configured: Option<&str>) -> IconSet {
-    resolve_with(configured, non_empty_env)
+    resolve_with(configured, non_empty_env, nerd_font_available)
 }
 
-/// [`resolve`] with the environment injected.
+/// [`resolve`] with the environment and the font probe injected.
 ///
-/// The seam exists for the tests: mutating the real process environment to
-/// exercise locale precedence would race every other test thread in the binary.
-fn resolve_with(configured: Option<&str>, env: impl Fn(&str) -> Option<String>) -> IconSet {
+/// Both seams exist for the tests. Mutating the real process environment to
+/// exercise locale precedence would race every other test thread in the binary,
+/// and the font probe reads the *host's* installed fonts — so without a seam
+/// every auto-detection test would pass or fail depending on whether the machine
+/// running it happens to have a Nerd Font, which is no test at all.
+fn resolve_with(
+    configured: Option<&str>,
+    env: impl Fn(&str) -> Option<String>,
+    has_nerd_font: impl Fn() -> bool,
+) -> IconSet {
     match configured.map(normalise_tier_name).as_deref() {
         Some("text") => IconSet::Text,
         Some("unicode") => IconSet::Unicode,
         Some("nerdfont") => IconSet::NerdFont,
         Some("emoji") => IconSet::Emoji,
-        _ => auto_detect(env),
+        _ => auto_detect(env, has_nerd_font),
     }
 }
 
@@ -282,23 +301,85 @@ fn normalise_tier_name(name: &str) -> String {
     name.trim().to_ascii_lowercase().replace(['-', '_'], "")
 }
 
-/// The best tier that needs no font install: [`IconSet::Unicode`] on a UTF-8
-/// locale, else [`IconSet::Text`].
+/// The best tier this machine looks able to draw: [`IconSet::NerdFont`] when a
+/// Nerd Font is installed, else [`IconSet::Text`].
 ///
-/// A non-UTF-8 locale is the one signal we can read locally that block glyphs
-/// will not survive the trip to the terminal, and it costs nothing to honour.
-/// Font *coverage* is not detectable from here at all, which is why the Unicode
-/// tier is restricted to glyphs measured to be in the stock faces.
-fn auto_detect(env: impl Fn(&str) -> Option<String>) -> IconSet {
+/// Two things this deliberately does NOT do, both learned the hard way:
+///
+/// - **It never auto-selects [`IconSet::Unicode`].** Those glyphs are *present*
+///   in the stock faces — that was measured — but `░`/`▒` are dither patterns,
+///   and at terminal sizes they render as an indistinct blob rather than a light
+///   shade. Present and legible are different properties, and only the first is
+///   measurable from here. The gauge stays available by explicit opt-in.
+/// - **It falls back to [`IconSet::Text`], never to something merely likely.**
+///   A wrong guess costs the user an unreadable sidebar, which is strictly worse
+///   than plain words.
+///
+/// The locale check gates the whole thing: a terminal that cannot carry UTF-8
+/// cannot carry a Nerd Font glyph either, and that is cheap to rule out first.
+fn auto_detect(env: impl Fn(&str) -> Option<String>, has_nerd_font: impl Fn() -> bool) -> IconSet {
     // `non_empty_env` treats an empty value as unset, which is also what POSIX
     // says about an empty `LC_ALL` — so an empty higher-precedence variable
     // correctly falls through to the next one.
     let locale = LOCALE_VARS.iter().find_map(|name| env(name));
-    if is_utf8_locale(locale.as_deref()) {
-        IconSet::Unicode
+    // Order matters: the locale check is a couple of `getenv`s, the font probe
+    // forks a process. Short-circuit means a `C`-locale host never pays for it.
+    if is_utf8_locale(locale.as_deref()) && has_nerd_font() {
+        IconSet::NerdFont
     } else {
         IconSet::Text
     }
+}
+
+// ---- Nerd Font probe ------------------------------------------------------------
+
+/// Whether some installed font carries [`NERD_CPU`], cached for the process.
+///
+/// **This detects "a Nerd Font is installed", not "your terminal uses one".**
+/// The distinction is not pedantry — it is the whole accuracy budget of this
+/// function. herdr draws the sidebar into whatever terminal emulator the user
+/// launched it from, and that emulator's font lives in its own config, which no
+/// plugin can read. Worse, the updater daemon runs detached with null stdio, so
+/// it has no terminal to interrogate even in principle: the usual trick of
+/// printing a glyph and asking the terminal where the cursor landed needs a TTY
+/// this process does not have.
+///
+/// So this is a heuristic with one known false positive — a Nerd Font present
+/// on disk but not selected in the terminal — which lands the user back on the
+/// boxes we are trying to avoid. It is chosen anyway because the alternative
+/// (never using icons) is worse for the many people who install a Nerd Font
+/// precisely to use it, and because the miss is one config line to correct after
+/// `--icons` shows it. `auto` is a convenience, not a contract.
+///
+/// Cached in a `OnceLock`: the daemon resolves the tier once per refresh, and
+/// forking `fc-list` every five seconds forever to be told the same thing would
+/// be indefensible.
+fn nerd_font_available() -> bool {
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| probe_nerd_font(NERD_CPU))
+}
+
+/// Ask fontconfig whether any installed font covers `glyph`.
+///
+/// `fc-list :charset=<hex>` prints one line per matching font and nothing at
+/// all when there is no match, so non-empty stdout IS the answer. Anything that
+/// goes wrong — no `fc-list` on `PATH`, a non-zero exit, a spawn failure — reads
+/// as "no", which falls back to [`IconSet::Text`]: the safe direction.
+///
+/// fontconfig is a Linux convention. macOS and Windows have their own font
+/// databases (CoreText, DirectWrite) and generally no `fc-list`, so `auto`
+/// yields `Text` there and those users pick a tier explicitly after running
+/// `--icons`. Querying CoreText/DirectWrite would mean real FFI against two more
+/// system APIs to sharpen a heuristic that still could not see the terminal's
+/// actual font — not worth it.
+fn probe_nerd_font(glyph: char) -> bool {
+    Command::new("fc-list")
+        .arg(format!(":charset={:x}", glyph as u32))
+        .arg("family")
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .is_ok_and(|out| out.status.success() && !out.stdout.is_empty())
 }
 
 /// Whether `locale` names a UTF-8 charset (`en_US.UTF-8`, `en_US.utf8`, …).
@@ -348,8 +429,19 @@ mod tests {
     }
 
     /// Resolve with no environment at all — isolates config parsing from locale.
+    /// A host with no locale and no Nerd Font — the most conservative machine.
     fn resolve_bare(configured: Option<&str>) -> IconSet {
-        resolve_with(configured, env_from(&[]))
+        resolve_with(configured, env_from(&[]), || false)
+    }
+
+    /// Probe stub: pretend a Nerd Font is installed.
+    fn has_nerd() -> bool {
+        true
+    }
+
+    /// Probe stub: pretend none is.
+    fn no_nerd() -> bool {
+        false
     }
 
     // ---- tier parsing --------------------------------------------------------
@@ -372,17 +464,42 @@ mod tests {
 
     #[test]
     fn auto_unknown_and_missing_all_fall_back_to_detection() {
-        // The bare environment detects `Text`; a UTF-8 one detects `Unicode`.
-        // Both must follow the *detector*, not a hardcoded default.
+        // A bare host detects `Text`; a UTF-8 host with a Nerd Font detects
+        // `NerdFont`. Both must follow the *detector*, not a hardcoded default.
         let utf8 = || env_from(&[("LANG", "en_US.UTF-8")]);
         for configured in [None, Some("auto"), Some("bogus"), Some("")] {
             assert_eq!(resolve_bare(configured), IconSet::Text, "{configured:?}");
             assert_eq!(
-                resolve_with(configured, utf8()),
-                IconSet::Unicode,
+                resolve_with(configured, utf8(), has_nerd),
+                IconSet::NerdFont,
                 "{configured:?}",
             );
         }
+    }
+
+    #[test]
+    fn auto_never_selects_the_unicode_gauge() {
+        // The gauge glyphs are *present* in the stock faces — measured — but
+        // `░`/`▒` are dither patterns that render as an indistinct blob at
+        // terminal sizes. Reported from a real sidebar, which is why `auto` no
+        // longer reaches for them. No combination of locale and font may bring
+        // it back; it stays available only by explicit opt-in.
+        for utf8 in [true, false] {
+            let env = if utf8 {
+                env_from(&[("LANG", "en_US.UTF-8")])
+            } else {
+                env_from(&[("LANG", "C")])
+            };
+            for probe in [has_nerd, no_nerd] {
+                assert_ne!(
+                    auto_detect(&env, probe),
+                    IconSet::Unicode,
+                    "auto picked the gauge (utf8={utf8})",
+                );
+            }
+        }
+        // ..but asking for it by name still works.
+        assert_eq!(resolve_bare(Some("unicode")), IconSet::Unicode);
     }
 
     // ---- locale auto-detection -----------------------------------------------
@@ -395,17 +512,49 @@ mod tests {
             ("LC_CTYPE", "en_US.UTF-8"),
             ("LANG", "en_US.UTF-8"),
         ]);
-        assert_eq!(auto_detect(all_wins), IconSet::Text);
+        assert_eq!(auto_detect(all_wins, has_nerd), IconSet::Text);
 
         let ctype_wins = env_from(&[("LC_CTYPE", "C"), ("LANG", "en_US.UTF-8")]);
-        assert_eq!(auto_detect(ctype_wins), IconSet::Text);
+        assert_eq!(auto_detect(ctype_wins, has_nerd), IconSet::Text);
 
         // An empty higher-precedence variable is unset, so the next one decides.
         let empty_falls_through = env_from(&[("LC_ALL", ""), ("LANG", "en_US.UTF-8")]);
-        assert_eq!(auto_detect(empty_falls_through), IconSet::Unicode);
+        assert_eq!(
+            auto_detect(empty_falls_through, has_nerd),
+            IconSet::NerdFont
+        );
 
         let lang_only = env_from(&[("LANG", "en_US.UTF-8")]);
-        assert_eq!(auto_detect(lang_only), IconSet::Unicode);
+        assert_eq!(auto_detect(lang_only, has_nerd), IconSet::NerdFont);
+    }
+
+    // ---- the Nerd Font probe ---------------------------------------------------
+
+    #[test]
+    fn a_utf8_locale_without_a_nerd_font_still_falls_back_to_text() {
+        // The safe direction. A machine that cannot draw the icons must get
+        // words, never a row of boxes.
+        let utf8 = env_from(&[("LANG", "en_US.UTF-8")]);
+        assert_eq!(auto_detect(utf8, no_nerd), IconSet::Text);
+    }
+
+    #[test]
+    fn the_font_probe_is_skipped_entirely_on_a_non_utf8_locale() {
+        // Short-circuit: the probe forks `fc-list`, so a `C`-locale host must
+        // never pay for it. Panicking from the stub proves it is not called.
+        let c_locale = env_from(&[("LANG", "C")]);
+        let must_not_run = || panic!("font probe ran despite a non-UTF-8 locale");
+        assert_eq!(auto_detect(c_locale, must_not_run), IconSet::Text);
+    }
+
+    #[test]
+    fn probing_for_an_absent_glyph_is_false_and_never_panics() {
+        // U+10FFFE is a permanent noncharacter, so no font can claim it. This
+        // also exercises the real `fc-list` path: on a host without fontconfig
+        // the spawn simply fails, which must read as "no" rather than blowing
+        // up. Either way the answer is false, so the test is deterministic
+        // across Linux, macOS, and Windows CI runners.
+        assert!(!probe_nerd_font('\u{10FFFE}'));
     }
 
     #[test]
@@ -421,13 +570,13 @@ mod tests {
     fn non_utf8_locales_fall_back_to_text() {
         for locale in ["C", "POSIX", "en_US", "en_US.ISO-8859-1", ""] {
             assert_eq!(
-                auto_detect(env_from(&[("LANG", locale)])),
+                auto_detect(env_from(&[("LANG", locale)]), has_nerd),
                 IconSet::Text,
                 "{locale:?}",
             );
         }
         // Nothing set at all is also Text.
-        assert_eq!(auto_detect(env_from(&[])), IconSet::Text);
+        assert_eq!(auto_detect(env_from(&[]), has_nerd), IconSet::Text);
         assert!(!is_utf8_locale(None));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,14 @@ mod daemon;
 mod herdr;
 mod icons;
 mod model;
-#[cfg(unix)]
+// One `proc` module per platform, selected here so every consumer just says
+// `proc::`. macOS is carved out of the unix arm because it has no `/proc`;
+// the other BSDs stay on the sysfs reader, which is what they had before and
+// is closer to right for them than the Darwin libproc backend would be.
+#[cfg(all(unix, not(target_os = "macos")))]
+mod proc;
+#[cfg(target_os = "macos")]
+#[path = "proc_macos.rs"]
 mod proc;
 #[cfg(windows)]
 #[path = "proc_windows.rs"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@
 //!   --once            print a single snapshot and exit (used by the action)
 //!   --interval N      live watch, refreshing every N seconds (used by the pane)
 //!   --json            emit machine-readable JSON and exit
+//!   --icons           preview every icon tier in this terminal and exit
 //!   --enable          start the sidebar status updater daemon
 //!   --disable         stop the daemon and clear statuses
 //!   --toggle          enable/disable depending on daemon state
@@ -48,6 +49,35 @@ pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 /// Default live-watch refresh window when `--interval` is absent or invalid.
 const DEFAULT_INTERVAL_MS: u64 = 2000;
 
+/// Every icon tier with the name `icons = ` takes for it, laddering up by how
+/// much each assumes about the user's font.
+///
+/// The names are the ones the user types into the plugin config, so
+/// `icon_tier_names_are_the_ones_the_config_accepts` pins them against
+/// [`icons::resolve`] — a preview that prints a name the config would not
+/// accept is worse than no preview.
+const ICON_TIERS: [(&str, icons::IconSet); 4] = [
+    ("text", icons::IconSet::Text),
+    ("unicode", icons::IconSet::Unicode),
+    ("nerdfont", icons::IconSet::NerdFont),
+    ("emoji", icons::IconSet::Emoji),
+];
+
+// The one sample reading `--icons` draws in every tier. Fixed rather than
+// measured from the host: the preview is about glyphs, and a row that changes
+// between runs is a row you cannot compare tiers with.
+
+/// Sample CPU load — low enough to sit on the gauge's first step.
+const SAMPLE_CPU: f64 = 26.0;
+/// Sample RAM share.
+const SAMPLE_RAM: f64 = 8.0;
+/// Sample battery: mid-ramp, so the tiers that vary their glyph by charge show
+/// a middle one, and charging, so the `+` mark appears.
+const SAMPLE_BATTERY: battery::Battery = battery::Battery {
+    percent: 74.0,
+    state: battery::State::Charging,
+};
+
 fn main() {
     if let Err(err) = run() {
         eprintln!("space-usage: {err}");
@@ -75,18 +105,62 @@ fn run() -> Result<()> {
         return daemon::restore_updater();
     }
 
+    let config = config::load_config();
+
+    // A pure local preview: it draws sample glyphs and reads two config files,
+    // so it must work with herdr down — hence ahead of `connect`.
+    if has_flag(&args, "--icons") {
+        print_icon_preview(&config, &config::load_herdr_labels());
+        return Ok(());
+    }
+
     // Read modes share one socket connection.
     let mut client = herdr::connect()?;
     if has_flag(&args, "--json") {
-        return render::run_json(&mut client);
+        return render::run_json(&mut client, &config);
     }
 
     let labels = config::load_herdr_labels();
     if has_flag(&args, "--once") {
-        return render::run_once(&mut client, &labels);
+        return render::run_once(&mut client, &labels, &config);
     }
 
-    render::run_interval(&mut client, &labels, interval_ms(&args))
+    render::run_interval(&mut client, &labels, &config, interval_ms(&args))
+}
+
+/// `--icons`: draw the same sample reading in all four tiers so the user can see
+/// which glyphs *their* terminal and font actually produce before choosing one.
+///
+/// Nothing here can be answered from inside the program: whether a Nerd Font is
+/// installed, or whether the terminal draws emoji at one column or two, is
+/// visible only to the person looking at the screen. So the preview shows the
+/// rows and lets them judge — a tier that comes out as boxes is one to avoid.
+///
+/// The rows use the user's own herdr `[ui]` labels and go through the same
+/// [`render::metric_row`] the sidebar does, so what they see is what they get.
+fn print_icon_preview(config: &config::Config, labels: &config::Labels) {
+    let current = config.icon_set();
+    println!(
+        "\n  Icon tiers — {SAMPLE_CPU:.0}% cpu, {SAMPLE_RAM:.0}% ram, \
+         {:.0}% battery charging, drawn by each tier:\n",
+        SAMPLE_BATTERY.percent,
+    );
+    for (name, set) in ICON_TIERS {
+        let row = render::metric_row(
+            set.cpu(&labels.cpu, SAMPLE_CPU),
+            set.ram(&labels.ram, SAMPLE_RAM),
+            Some(set.battery(&labels.battery, SAMPLE_BATTERY)),
+        );
+        let marker = if set == current { "   <- current" } else { "" };
+        println!("    {name:<10}{row}{marker}");
+    }
+    println!(
+        "\n  text and unicode need no font installed. nerdfont needs a Nerd Font\n  \
+         and emoji needs a colour emoji font — if either row above came out as\n  \
+         boxes or blanks, that tier is not available here.\n\n  \
+         Choose one with `icons = \"<tier>\"` in the plugin's config.toml. The\n  \
+         default, `auto`, picks unicode on a UTF-8 locale and text otherwise.\n"
+    );
 }
 
 /// True if `flag` appears anywhere in `args`.
@@ -104,4 +178,35 @@ fn interval_ms(args: &[String]) -> u64 {
         .filter(|&n| n > 0.0)
         .map(|n| (n * 1000.0) as u64)
         .unwrap_or(DEFAULT_INTERVAL_MS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- the --icons preview -------------------------------------------------
+
+    #[test]
+    fn icon_tier_names_are_the_ones_the_config_accepts() {
+        // The preview tells the user to type these names into `icons = `, so a
+        // name the config parser would not recognise is a broken instruction.
+        for (name, set) in ICON_TIERS {
+            assert_eq!(icons::resolve(Some(name)), set, "{name}");
+        }
+    }
+
+    #[test]
+    fn every_tier_is_previewed() {
+        // A tier the user can select but cannot preview is one they would have
+        // to try blind, which is the whole problem `--icons` exists to solve.
+        let previewed: Vec<icons::IconSet> = ICON_TIERS.iter().map(|&(_, set)| set).collect();
+        for set in [
+            icons::IconSet::Text,
+            icons::IconSet::Unicode,
+            icons::IconSet::NerdFont,
+            icons::IconSet::Emoji,
+        ] {
+            assert!(previewed.contains(&set), "{set:?} is missing from --icons");
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,19 +147,46 @@ fn print_icon_preview(config: &config::Config, labels: &config::Labels) {
     );
     for (name, set) in ICON_TIERS {
         let row = render::metric_row(
-            set.cpu(&labels.cpu, SAMPLE_CPU),
-            set.ram(&labels.ram, SAMPLE_RAM),
-            Some(set.battery(&labels.battery, SAMPLE_BATTERY)),
+            set.cpu(labels.cpu(), SAMPLE_CPU),
+            set.ram(labels.ram(), SAMPLE_RAM),
+            Some(set.battery(labels.battery(), SAMPLE_BATTERY)),
         );
         let marker = if set == current { "   <- current" } else { "" };
         println!("    {name:<10}{row}{marker}");
     }
     println!(
         "\n  text and unicode need no font installed. nerdfont needs a Nerd Font\n  \
-         and emoji needs a colour emoji font — if either row above came out as\n  \
-         boxes or blanks, that tier is not available here.\n\n  \
+         and emoji needs a colour emoji font — if a row above came out as boxes\n  \
+         or blanks, that tier is not available here.\n\n  \
          Choose one with `icons = \"<tier>\"` in the plugin's config.toml. The\n  \
-         default, `auto`, picks unicode on a UTF-8 locale and text otherwise.\n"
+         default, `auto`, uses a Nerd Font when it finds one installed and plain\n  \
+         text otherwise.\n"
+    );
+    print_one_setting_hint(current);
+}
+
+/// Explain — and print — the single edit that keeps herdr's own sidebar header
+/// in step with these rows.
+///
+/// Worth the extra paragraph because the failure it prevents is invisible until
+/// you look at the sidebar: on a patched build the whole-machine system-usage
+/// header renders from herdr's `cpu_label` / `ram_label`, so setting only the
+/// plugin's `icons` leaves that header spelling `cpu` in words directly above a
+/// row of glyphs. Those two keys are the one place that changes both.
+fn print_one_setting_hint(current: icons::IconSet) {
+    let snippet = icons::herdr_ui_snippet(current);
+    let indented: String = snippet
+        .lines()
+        .map(|line| format!("      {line}\n"))
+        .collect();
+    println!(
+        "  One setting for both: herdr's own sidebar system-usage header reads\n  \
+         `cpu_label` / `ram_label` from ITS config, and this plugin honours the\n  \
+         same keys — an explicit label replaces the tier's glyph rather than\n  \
+         stacking with it. Set them once and the header and these rows agree.\n\n  \
+         For the tier above, put this in herdr's config.toml\n  \
+         (alongside `icons = \"text\"` here, since the labels now do the naming):\n\n\
+         {indented}"
     );
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,10 @@ fn run() -> Result<()> {
     // A pure local preview: it draws sample glyphs and reads two config files,
     // so it must work with herdr down — hence ahead of `connect`.
     if has_flag(&args, "--icons") {
-        print_icon_preview(&config, &config::load_herdr_labels());
+        print_icon_preview(
+            &config,
+            &config::load_herdr_labels().with_overrides(&config),
+        );
         return Ok(());
     }
 
@@ -120,7 +123,7 @@ fn run() -> Result<()> {
         return render::run_json(&mut client, &config);
     }
 
-    let labels = config::load_herdr_labels();
+    let labels = config::load_herdr_labels().with_overrides(&config);
     if has_flag(&args, "--once") {
         return render::run_once(&mut client, &labels, &config);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,10 +19,12 @@
 //! Linux and Windows: the `proc` module reads `/proc` on Linux and the Win32
 //! process APIs on Windows. herdr injects HERDR_BIN_PATH / HERDR_PLUGIN_*.
 
+mod battery;
 mod collect;
 mod config;
 mod daemon;
 mod herdr;
+mod icons;
 mod model;
 #[cfg(unix)]
 mod proc;

--- a/src/proc_macos.rs
+++ b/src/proc_macos.rs
@@ -1,0 +1,467 @@
+//! macOS process sampling — the `proc` module twin of the Linux `/proc` reader.
+//!
+//! Same public surface as `proc.rs`, different probes: the process table comes
+//! from `proc_listallpids`, parent PIDs and the executable name from
+//! `proc_pidinfo(PROC_PIDTBSDINFO)`, cumulative CPU time and RSS from
+//! `proc_pidinfo(PROC_PIDTASKINFO)`, and the machine total from
+//! `sysctl hw.memsize`. Processes whose *times* we cannot read (other users,
+//! platform-binary protections) still contribute their pid/ppid edge — the
+//! subtree walk needs the topology even when the counters are unreadable — but
+//! sample as zero CPU/RSS, which is correct for panes we own: a herdr pane's
+//! subtree runs as the current user.
+//!
+//! **CPU units.** `proc_taskinfo` reports nanoseconds, not clock ticks, so
+//! [`ProcEntry::jiffies`] holds nanoseconds and [`clk_tck`] returns 10^9. That
+//! is the whole trick that lets the three backends share one formula: the maths
+//! in `collect::measure` is `Δjiffies / clk_tck() / elapsed_s / nproc()`, so any
+//! backend may pick its own unit as long as `clk_tck()` names it. Linux uses
+//! `_SC_CLK_TCK` jiffies (100), Windows 100 ns FILETIME ticks (10^7).
+
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+
+/// Per-process sample: parent PID and cumulative CPU time in [`clk_tck`] units
+/// (here nanoseconds — see the module docs; the Linux twin uses jiffies).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ProcEntry {
+    pub ppid: u32,
+    pub jiffies: u64,
+}
+
+/// CPU-time units per second: `proc_taskinfo` totals are in nanoseconds.
+pub fn clk_tck() -> u64 {
+    1_000_000_000
+}
+
+/// Read a positive `sysconf(name)` value, falling back when it is unavailable.
+fn sysconf(name: libc::c_int, fallback: u64) -> u64 {
+    // SAFETY: `sysconf` is a pure query of a static system value.
+    let v = unsafe { libc::sysconf(name) };
+    if v > 0 {
+        v as u64
+    } else {
+        fallback
+    }
+}
+
+/// Number of online logical CPUs (`_SC_NPROCESSORS_ONLN`); normalizes CPU%.
+/// At least 1.
+pub fn nproc() -> u64 {
+    sysconf(libc::_SC_NPROCESSORS_ONLN, 1).max(1)
+}
+
+/// Slack added to the pid buffer so a fork racing the sizing call still fits.
+/// The kernel already pads its own answer by 20; this is belt and braces.
+const PID_HEADROOM: usize = 32;
+
+/// How many times to grow-and-retry when the pid buffer comes back full.
+const PID_LIST_ATTEMPTS: usize = 4;
+
+/// Every live pid, via `proc_listallpids`.
+///
+/// Called with a null buffer it answers "how many pids?" (the kernel pads that
+/// count by 20 itself); called with a buffer it fills it and returns how many
+/// it wrote. Both are counts, not byte lengths — `proc_listallpids` divides the
+/// kernel's byte count by `sizeof(int)` for us. A buffer that comes back
+/// completely full may have been truncated, so we grow and ask again.
+fn list_pids() -> Vec<u32> {
+    let mut capacity = 0usize;
+    for _ in 0..PID_LIST_ATTEMPTS {
+        // SAFETY: a null buffer with size 0 is the documented sizing query.
+        let needed = unsafe { libc::proc_listallpids(std::ptr::null_mut(), 0) };
+        if needed <= 0 {
+            return Vec::new();
+        }
+        capacity = capacity.max(needed as usize + PID_HEADROOM);
+
+        let mut pids = vec![0 as libc::c_int; capacity];
+        let bytes = (capacity * std::mem::size_of::<libc::c_int>()) as libc::c_int;
+        // SAFETY: `pids` owns `capacity` c_ints and `bytes` is exactly that
+        // span in bytes, so the kernel cannot write past the allocation.
+        let count = unsafe { libc::proc_listallpids(pids.as_mut_ptr().cast(), bytes) };
+        if count <= 0 {
+            return Vec::new();
+        }
+        let count = count as usize;
+        if count >= capacity {
+            capacity *= 2; // filled to the brim — assume truncation and retry
+            continue;
+        }
+        pids.truncate(count);
+        // pid 0 is `kernel_task`, a pseudo-process and not a real tree root
+        // (launchd is pid 1, parented to 0), so drop it like the Windows twin
+        // drops System Idle.
+        return pids
+            .into_iter()
+            .filter(|&pid| pid > 0)
+            .map(|pid| pid as u32)
+            .collect();
+    }
+    Vec::new()
+}
+
+/// Fetch one `proc_pidinfo` flavor for `pid`, or `None` when it is unavailable.
+///
+/// `proc_pidinfo` returns the number of bytes it wrote, or <= 0 on failure —
+/// EPERM for a process we may not inspect, ESRCH once it exits. A short write
+/// leaves the tail of the struct zeroed, which would read back as a perfectly
+/// plausible "0 ns of CPU, 0 bytes resident" sample, so anything less than a
+/// full-size write is treated as failure rather than as data.
+///
+/// # Safety
+///
+/// `T` must be the plain-old-data FFI struct that `flavor` fills, and one for
+/// which an all-zero bit pattern is a valid value.
+unsafe fn pid_info<T>(pid: u32, flavor: libc::c_int) -> Option<T> {
+    let mut info: T = std::mem::zeroed();
+    let size = std::mem::size_of::<T>() as libc::c_int;
+    let written = libc::proc_pidinfo(
+        pid as libc::c_int,
+        flavor,
+        0,
+        (&mut info as *mut T).cast(),
+        size,
+    );
+    (written == size).then_some(info)
+}
+
+/// Cumulative user+system CPU nanoseconds and RSS bytes for `pid`.
+fn task_info(pid: u32) -> Option<libc::proc_taskinfo> {
+    // SAFETY: `proc_taskinfo` is the POD struct PROC_PIDTASKINFO fills.
+    unsafe { pid_info::<libc::proc_taskinfo>(pid, libc::PROC_PIDTASKINFO) }
+}
+
+/// Parent pid and executable name for `pid`.
+fn bsd_info(pid: u32) -> Option<libc::proc_bsdinfo> {
+    // SAFETY: `proc_bsdinfo` is the POD struct PROC_PIDTBSDINFO fills.
+    unsafe { pid_info::<libc::proc_bsdinfo>(pid, libc::PROC_PIDTBSDINFO) }
+}
+
+/// Snapshot the process table once, returning `pid -> {ppid, cpu ns}` for every
+/// live process. Processes whose times are unreadable keep their pid/ppid edge
+/// (the subtree walk needs it) with zero CPU; processes that vanish mid-scan,
+/// or whose parent link we cannot read at all, are skipped.
+pub fn scan_proc() -> HashMap<u32, ProcEntry> {
+    let mut procs = HashMap::new();
+    for pid in list_pids() {
+        // No ppid means no edge worth recording — the pid exited between the
+        // listing and now, or is one we may not inspect.
+        let Some(bsd) = bsd_info(pid) else {
+            continue;
+        };
+        // Times, unlike the parent link, are optional: dropping an intermediate
+        // node whose counters we cannot read would orphan every descendant
+        // below it and under-report the workspace.
+        let jiffies = task_info(pid)
+            .map(|ti| ti.pti_total_user + ti.pti_total_system)
+            .unwrap_or(0);
+        procs.insert(
+            pid,
+            ProcEntry {
+                ppid: bsd.pbi_ppid,
+                jiffies,
+            },
+        );
+    }
+    procs
+}
+
+/// A fixed-width C string field as a `String`, stopping at the first NUL — and
+/// at the end of the field if the kernel filled every byte without one.
+fn c_str_field(field: &[libc::c_char]) -> String {
+    let bytes: Vec<u8> = field
+        .iter()
+        .take_while(|&&c| c != 0)
+        .map(|&c| c as u8)
+        .collect();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+/// Pick the executable name out of a `proc_bsdinfo`'s two name fields.
+///
+/// `pbi_name` is the 31-char `p_name`, `pbi_comm` the 15-char `p_comm`.
+/// `p_name` is empty for a process that never exec'd, so fall back to `p_comm`
+/// — the same order `libproc`'s own `proc_name()` uses. `p_comm` is the exact
+/// analogue of Linux `/proc/<pid>/comm`, which is what that backend returns.
+/// Both empty reads as `None`: an empty name would compare equal to another
+/// empty name, and the daemon's stale-pid guard compares names.
+fn image_name(name: &[libc::c_char], comm: &[libc::c_char]) -> Option<String> {
+    let name = c_str_field(name);
+    if !name.is_empty() {
+        return Some(name);
+    }
+    let comm = c_str_field(comm);
+    if comm.is_empty() {
+        None
+    } else {
+        Some(comm)
+    }
+}
+
+/// Executable name of `pid`, or `None` when the process is gone or unreadable.
+/// Used by the daemon's stale-pid-file guard; also doubles as the liveness
+/// probe (a vanished pid has no bsdinfo to read).
+pub fn process_image_name(pid: u32) -> Option<String> {
+    let info = bsd_info(pid)?;
+    image_name(&info.pbi_name, &info.pbi_comm)
+}
+
+/// Best-effort graceful stop of `pid` via SIGTERM (failure is ignored — the
+/// daemon's statuses self-clear via their TTL either way).
+pub fn stop_process(pid: u32) {
+    // SAFETY: `kill` merely posts SIGTERM to the pid.
+    unsafe {
+        libc::kill(pid as i32, libc::SIGTERM);
+    }
+}
+
+/// Invert a proc map into `ppid -> [child pid, ..]`.
+pub fn children_map(procs: &HashMap<u32, ProcEntry>) -> HashMap<u32, Vec<u32>> {
+    let mut kids: HashMap<u32, Vec<u32>> = HashMap::new();
+    for (&pid, p) in procs {
+        kids.entry(p.ppid).or_default().push(pid);
+    }
+    kids
+}
+
+/// Every PID in `root`'s process subtree (inclusive), via the children map.
+/// Iterative DFS with a visited set, so shared parents and cycles terminate.
+pub fn subtree(root: u32, kids: &HashMap<u32, Vec<u32>>) -> HashSet<u32> {
+    let mut out = HashSet::new();
+    let mut stack = vec![root];
+    while let Some(pid) = stack.pop() {
+        if !out.insert(pid) {
+            continue; // already visited — dedup
+        }
+        if let Some(children) = kids.get(&pid) {
+            stack.extend(children.iter().copied());
+        }
+    }
+    out
+}
+
+/// Bytes to MB, matching the Linux twin's kB/1024 (i.e. MiB, as every RAM
+/// readout on these platforms means).
+fn bytes_to_mb(bytes: u64) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0)
+}
+
+/// Physical RAM in bytes from `sysctl hw.memsize`, or `None` if the call fails.
+fn hw_memsize() -> Option<u64> {
+    let mut mib: [libc::c_int; 2] = [libc::CTL_HW, libc::HW_MEMSIZE];
+    let mut bytes: u64 = 0;
+    let mut len = std::mem::size_of::<u64>();
+    // SAFETY: `mib` is a 2-entry MIB matching the `namelen` we pass; `bytes`
+    // and `len` are a correctly sized caller-owned out-param pair; the null
+    // `newp` / zero `newlen` make this a read.
+    let rc = unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            mib.len() as libc::c_uint,
+            (&mut bytes as *mut u64).cast(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    (rc == 0 && len == std::mem::size_of::<u64>()).then_some(bytes)
+}
+
+/// Total physical RAM in MB via `sysctl hw.memsize` (0 if the call fails).
+/// Read once and cached for the process lifetime.
+pub fn mem_total_mb() -> f64 {
+    static MEM_TOTAL_MB: OnceLock<f64> = OnceLock::new();
+    *MEM_TOTAL_MB.get_or_init(|| hw_memsize().map(bytes_to_mb).unwrap_or(0.0))
+}
+
+/// Render `mb` as a whole-percent-of-`total_mb` string, or `""` when unknown.
+fn pct_string(mb: f64, total_mb: f64) -> String {
+    if total_mb > 0.0 {
+        // `round()` is half-away-from-zero, which for these non-negative
+        // values is ordinary half-up rounding.
+        format!("{}%", (100.0 * mb / total_mb).round() as i64)
+    } else {
+        String::new()
+    }
+}
+
+/// `"<n>%"` of total system RAM for `mb`, or `""` if the total is unknown.
+pub fn ram_pct(mb: f64) -> String {
+    pct_string(mb, mem_total_mb())
+}
+
+/// Sum of RSS (MB) across `pids` — `pti_resident_size`, the Mach task's
+/// resident footprint and the closest analogue of Linux RSS. Vanished or
+/// unreadable pids contribute nothing.
+pub fn rss_mb(pids: &HashSet<u32>) -> f64 {
+    let mut bytes: u64 = 0;
+    for &pid in pids {
+        if let Some(ti) = task_info(pid) {
+            bytes += ti.pti_resident_size;
+        }
+    }
+    bytes_to_mb(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fixed-width C string field holding `text`, NUL-padded — or flush to
+    /// the edge with no terminator when `text` is exactly `width` long.
+    fn field(text: &str, width: usize) -> Vec<libc::c_char> {
+        let mut out: Vec<libc::c_char> = text.bytes().map(|b| b as libc::c_char).collect();
+        out.resize(width, 0);
+        out
+    }
+
+    // ---- pure helpers (mirroring proc.rs, held to the same contract) ----
+
+    #[test]
+    fn subtree_walks_descendants_with_dedup_and_cycle_safety() {
+        // Diamond (4 reachable via both 2 and 3) exercises dedup; the 4 -> 1
+        // back-edge is a cycle that must still terminate.
+        let mut kids: HashMap<u32, Vec<u32>> = HashMap::new();
+        kids.insert(1, vec![2, 3]);
+        kids.insert(2, vec![4]);
+        kids.insert(3, vec![4]);
+        kids.insert(4, vec![1]);
+        kids.insert(999, vec![6]); // unrelated tree — must not be pulled in
+
+        let got = subtree(1, &kids);
+        assert_eq!(got, HashSet::from([1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn children_map_then_subtree_over_synthetic_procs() {
+        let procs: HashMap<u32, ProcEntry> = [
+            (1, 0),   // root
+            (2, 1),   // child of 1
+            (3, 1),   // child of 1
+            (4, 2),   // grandchild
+            (5, 4),   // great-grandchild
+            (6, 999), // unrelated subtree
+        ]
+        .into_iter()
+        .map(|(pid, ppid)| (pid, ProcEntry { ppid, jiffies: 0 }))
+        .collect();
+
+        let kids = children_map(&procs);
+        assert_eq!(subtree(1, &kids), HashSet::from([1, 2, 3, 4, 5]));
+    }
+
+    #[test]
+    fn ram_pct_math_rounds_and_guards_zero_total() {
+        // 100 * 1024 / 16384 = 6.25 -> 6
+        assert_eq!(pct_string(1024.0, 16384.0), "6%");
+        // 100 * 250 / 10000 = 2.5 -> 3 (half away from zero)
+        assert_eq!(pct_string(250.0, 10000.0), "3%");
+        // full machine
+        assert_eq!(pct_string(16384.0, 16384.0), "100%");
+        // unknown total -> empty string
+        assert_eq!(pct_string(512.0, 0.0), "");
+    }
+
+    #[test]
+    fn cpu_unit_is_nanoseconds() {
+        // The contract that lets this backend share `collect::measure` with the
+        // other two: whatever unit `jiffies` is in, `clk_tck()` names it.
+        // `proc_taskinfo` is nanoseconds, so one second must be 10^9 units.
+        assert_eq!(clk_tck(), 1_000_000_000);
+    }
+
+    #[test]
+    fn bytes_convert_to_mebibytes() {
+        assert_eq!(bytes_to_mb(0), 0.0);
+        assert_eq!(bytes_to_mb(1024 * 1024), 1.0);
+        assert_eq!(bytes_to_mb(16 * 1024 * 1024 * 1024), 16384.0); // 16 GiB
+        assert_eq!(bytes_to_mb(512 * 1024), 0.5);
+    }
+
+    #[test]
+    fn c_str_field_stops_at_nul_and_tolerates_no_terminator() {
+        assert_eq!(c_str_field(&field("bash", 16)), "bash");
+        // Exactly MAXCOMLEN bytes with no room for a NUL — take the lot.
+        assert_eq!(
+            c_str_field(&field("exactly-16-chars", 16)),
+            "exactly-16-chars"
+        );
+        // Garbage past the terminator is not ours to read.
+        let mut padded = field("zsh", 16);
+        padded[8] = b'X' as libc::c_char;
+        assert_eq!(c_str_field(&padded), "zsh");
+        assert_eq!(c_str_field(&field("", 16)), "");
+    }
+
+    #[test]
+    fn image_name_prefers_p_name_and_falls_back_to_comm() {
+        // p_name is the longer field, so it wins when populated.
+        assert_eq!(
+            image_name(&field("space-usage", 32), &field("space-usage", 16)),
+            Some("space-usage".to_string())
+        );
+        // Never exec'd: p_name is empty, p_comm still names the process.
+        assert_eq!(
+            image_name(&field("", 32), &field("kernel_task", 16)),
+            Some("kernel_task".to_string())
+        );
+        // Nothing at all — `None`, so the daemon's guard cannot match two
+        // nameless processes to each other.
+        assert_eq!(image_name(&field("", 32), &field("", 16)), None);
+    }
+
+    // ---- live probes (macOS CI runner; assert only what any Mac grants) ----
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn scan_includes_our_own_process_with_parent_and_cpu_time() {
+        let procs = scan_proc();
+        let me = procs
+            .get(&std::process::id())
+            .expect("our own pid is in the snapshot");
+        // SAFETY: `getppid` is a pure query of our own process state.
+        let parent = unsafe { libc::getppid() } as u32;
+        assert_eq!(me.ppid, parent, "own parent pid mismatch");
+        // Our own task is always readable, so its CPU counter is real.
+        assert!(
+            me.jiffies > 0,
+            "own cumulative CPU nanoseconds read as zero"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn pid_listing_finds_us_and_launchd() {
+        let pids = list_pids();
+        assert!(pids.contains(&std::process::id()), "own pid missing");
+        assert!(pids.contains(&1), "launchd (pid 1) missing");
+        assert!(!pids.contains(&0), "kernel_task pseudo-pid not filtered");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn own_image_name_is_reported_and_vanished_pid_is_none() {
+        let name = process_image_name(std::process::id()).expect("own image name");
+        assert!(!name.is_empty());
+        assert_eq!(process_image_name(u32::MAX), None);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn machine_ram_total_is_positive() {
+        assert!(mem_total_mb() > 0.0);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn own_rss_is_positive() {
+        let pids = HashSet::from([std::process::id()]);
+        assert!(rss_mb(&pids) > 0.0);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn nproc_is_at_least_one() {
+        assert!(nproc() >= 1);
+    }
+}

--- a/src/render.rs
+++ b/src/render.rs
@@ -4,15 +4,22 @@
 //! builds the machine-readable payload. The `run_*` helpers drive a
 //! [`collect::snapshot`](crate::collect::snapshot) and print the result, with
 //! `run_interval` clearing and redrawing each frame.
+//!
+//! Every surface's metric cells are assembled here — including the narrow ones
+//! the sidebar daemon and the `--icons` preview draw ([`usage_row`]) — so there
+//! is one place that decides what a metric looks like and the surfaces cannot
+//! drift apart.
 
 use std::io::{self, IsTerminal, Write};
 
 use serde::Serialize;
 use serde_json::Number;
 
+use crate::battery::{Battery, State};
 use crate::collect;
-use crate::config::Labels;
+use crate::config::{Config, Labels};
 use crate::herdr::Herdr;
+use crate::icons::IconSet;
 use crate::model::Space;
 use crate::proc;
 
@@ -88,16 +95,119 @@ fn fmt_ram(mb: f64) -> String {
     }
 }
 
+/// Compact absolute RAM: `"<x.x>G"` at/above 1024 MB, else `"<n>M"`
+/// — the narrow form the sidebar falls back to.
+fn compact_ram(mb: f64) -> String {
+    if mb >= 1024.0 {
+        format!("{:.1}G", mb / 1024.0)
+    } else {
+        format!("{}M", mb.round() as i64)
+    }
+}
+
+// ---- narrow metric cells ----------------------------------------------------
+//
+// The sidebar status, the window title, and the `--icons` preview all draw the
+// same few characters, so they all build them here.
+
+/// Separator between the cells of a narrow metric row.
+const CELL_SEPARATOR: &str = " · ";
+
+/// The narrow RAM cell — the tier's rendering of RAM as a percent of the
+/// machine's total (`ram ░8%`).
+///
+/// RAM is the one metric that is not simply a percentage. With MemTotal
+/// unreadable there is nothing to be a percentage *of*, so the cell falls back
+/// to the compact absolute (`ram 1.5G`) the sidebar has always shown there. The
+/// tier deliberately contributes nothing in that branch: a gauge glyph measures
+/// a level, and drawing one beside an absolute figure would be inventing a
+/// reading we do not have.
+fn ram_cell(icons: IconSet, label: &str, mb: f64) -> String {
+    ram_cell_of(icons, label, mb, proc::mem_total_mb())
+}
+
+/// [`ram_cell`] with the machine total injected.
+///
+/// The seam exists for the tests: the real total is read once and cached for the
+/// process, so a test host with a readable `/proc/meminfo` could never reach the
+/// fallback branch (and one without it could never reach the percent branch).
+fn ram_cell_of(icons: IconSet, label: &str, mb: f64, mem_total_mb: f64) -> String {
+    if mem_total_mb > 0.0 {
+        // Same arithmetic and rounding as `proc::ram_pct`, so the Text tier
+        // reproduces the pre-icons sidebar byte for byte.
+        icons.ram(label, 100.0 * mb / mem_total_mb)
+    } else {
+        format!("{label} {}", compact_ram(mb))
+    }
+}
+
+/// The battery cell, or nothing when there is no reading to show.
+///
+/// A helper rather than a `map` at each call site so the sidebar row, the window
+/// title, and the report's total line cannot disagree about what a battery looks
+/// like. `reading` is already `None` when the user turned the metric off — see
+/// [`Config::battery_reading`].
+fn battery_cell(icons: IconSet, labels: &Labels, reading: Option<Battery>) -> Option<String> {
+    reading.map(|reading| icons.battery(&labels.battery, reading))
+}
+
+/// Join the cells of one narrow row: `cpu ░26% · ram ░8% · bat ▓74%`.
+///
+/// Split from [`usage_row`] so the `--icons` preview can feed it fixed sample
+/// percentages — a preview built out of the host's real RAM total would show a
+/// different row on every machine — while still going through the one function
+/// that decides cell order and separator.
+pub fn metric_row(cpu: String, ram: String, battery: Option<String>) -> String {
+    let mut cells = vec![cpu, ram];
+    cells.extend(battery); // absent battery: no cell, no trailing separator
+    cells.join(CELL_SEPARATOR)
+}
+
+/// One set of totals as a narrow row — what the sidebar card and the window
+/// title show.
+///
+/// `battery` is the machine-wide reading taken once per refresh cycle by
+/// [`Config::battery_reading`] and passed down, never re-read here: this runs
+/// once per space, and the battery is one value for the whole machine.
+pub fn usage_row(
+    cpu: f64,
+    ram_mb: f64,
+    labels: &Labels,
+    icons: IconSet,
+    battery: Option<Battery>,
+) -> String {
+    metric_row(
+        icons.cpu(&labels.cpu, cpu),
+        ram_cell(icons, &labels.ram, ram_mb),
+        battery_cell(icons, labels, battery),
+    )
+}
+
 // ---- human render -----------------------------------------------------------
 
 /// Format the per-space CPU/RAM report as a coloured, multi-line string.
-pub fn render(spaces: &[Space], labels: &Labels) -> String {
-    render_styled(spaces, labels, &Style::detect())
+///
+/// `battery` lands on the total line and nowhere else. It is one number for the
+/// whole machine, so stamping the same figure onto every space's row would be
+/// noise in a report this wide — and worse, would read as if it were per-space.
+pub fn render(
+    spaces: &[Space],
+    labels: &Labels,
+    icons: IconSet,
+    battery: Option<Battery>,
+) -> String {
+    render_styled(spaces, labels, icons, battery, &Style::detect())
 }
 
 /// Colour-parametrised body of [`render`] (split out so tests can force a
 /// deterministic no-colour rendering).
-fn render_styled(spaces: &[Space], labels: &Labels, style: &Style) -> String {
+fn render_styled(
+    spaces: &[Space],
+    labels: &Labels,
+    icons: IconSet,
+    battery: Option<Battery>,
+    style: &Style,
+) -> String {
     let mut lines: Vec<String> = vec![style.bold("  CPU / RAM per space"), String::new()];
     if spaces.is_empty() {
         lines.push(style.dim("  No spaces open."));
@@ -163,13 +273,19 @@ fn render_styled(spaces: &[Space], labels: &Labels, style: &Style) -> String {
     } else {
         format!(" ({total_pct})")
     };
+    // Three spaces is the gap between the total line's other cells, so the
+    // battery joins the row rather than looking bolted on.
+    let total_battery_str = battery_cell(icons, labels, battery)
+        .map(|cell| format!("   {cell}"))
+        .unwrap_or_default();
     lines.push(style.dim(&format!(
-        "  ── total   {} {:.1}%   {} {}{}",
+        "  ── total   {} {:.1}%   {} {}{}{}",
         labels.cpu,
         total_cpu,
         labels.ram,
         fmt_ram(total_ram),
         total_pct_str,
+        total_battery_str,
     )));
 
     lines.join("\n")
@@ -196,6 +312,32 @@ struct JsonSpace {
     /// value omits the key entirely rather than emitting `null`.
     #[serde(skip_serializing_if = "Option::is_none")]
     includes_worktrees: Option<Vec<String>>,
+    /// Machine-wide battery charge, repeated on every row — the payload's top
+    /// level is an array of spaces, and adding a wrapper object to hold one
+    /// machine-wide field would break every existing consumer. `null` on a host
+    /// with no battery (and when the user set `battery = false`, which reads the
+    /// same way from here: there is nothing to report).
+    ///
+    /// Trailing, like [`Self::battery_state`], so the keys every existing
+    /// consumer already reads keep their positions.
+    battery_percent: Option<Number>,
+    /// Charge state as a lowercase string (`charging`, `discharging`, `full`,
+    /// `not_charging`, `unknown`), or `null` alongside a `null` percentage.
+    battery_state: Option<String>,
+}
+
+/// The wire spelling of a charge state: lowercase, `snake_case`, and stable.
+///
+/// Exhaustive on purpose — a new [`State`] variant must fail the build here
+/// rather than silently serialize as something a consumer has never seen.
+fn battery_state_key(state: State) -> &'static str {
+    match state {
+        State::Charging => "charging",
+        State::Discharging => "discharging",
+        State::Full => "full",
+        State::NotCharging => "not_charging",
+        State::Unknown => "unknown",
+    }
 }
 
 /// Round to one decimal, then collapse a whole result to an integer so the
@@ -211,7 +353,10 @@ fn json_num_1dp(x: f64) -> Number {
 
 /// Serialize spaces to the `--json` payload (array of per-space objects), 2-space
 /// indented. No trailing newline.
-pub fn render_json(spaces: &[Space]) -> String {
+///
+/// `battery` is the one reading taken for this snapshot, copied onto every row —
+/// see [`JsonSpace::battery_percent`] for why it rides along per space.
+pub fn render_json(spaces: &[Space], battery: Option<Battery>) -> String {
     let mem_total = proc::mem_total_mb();
     let payload: Vec<JsonSpace> = spaces
         .iter()
@@ -226,6 +371,8 @@ pub fn render_json(spaces: &[Space]) -> String {
             ram_mb: json_num_1dp(s.ram_mb),
             ram_percent: (mem_total > 0.0).then(|| json_num_1dp(100.0 * s.ram_mb / mem_total)),
             includes_worktrees: s.worktree_labels.clone(),
+            battery_percent: battery.map(|b| json_num_1dp(b.percent)),
+            battery_state: battery.map(|b| battery_state_key(b.state).to_string()),
         })
         .collect();
     serde_json::to_string_pretty(&payload).unwrap_or_else(|_| "[]".to_string())
@@ -234,16 +381,19 @@ pub fn render_json(spaces: &[Space]) -> String {
 // ---- run modes --------------------------------------------------------------
 
 /// `--once`: print a single rendered snapshot and return.
-pub fn run_once(client: &mut Herdr, labels: &Labels) -> crate::Result<()> {
+pub fn run_once(client: &mut Herdr, labels: &Labels, config: &Config) -> crate::Result<()> {
     let spaces = collect::snapshot(client, SNAPSHOT_WINDOW_MS)?;
-    println!("{}", render(&spaces, labels));
+    println!(
+        "{}",
+        render(&spaces, labels, config.icon_set(), config.battery_reading()),
+    );
     Ok(())
 }
 
 /// `--json`: print one JSON snapshot and return.
-pub fn run_json(client: &mut Herdr) -> crate::Result<()> {
+pub fn run_json(client: &mut Herdr, config: &Config) -> crate::Result<()> {
     let spaces = collect::snapshot(client, SNAPSHOT_WINDOW_MS)?;
-    println!("{}", render_json(&spaces));
+    println!("{}", render_json(&spaces, config.battery_reading()));
     Ok(())
 }
 
@@ -252,22 +402,32 @@ pub fn run_json(client: &mut Herdr) -> crate::Result<()> {
 /// A SIGINT/SIGTERM hook (a console ctrl handler on Windows) restores the
 /// cursor and exits; the main loop hides the cursor, then clears + redraws each
 /// frame, widening the CPU window from the quick first frame to `interval_ms`.
-pub fn run_interval(client: &mut Herdr, labels: &Labels, interval_ms: u64) -> crate::Result<()> {
+pub fn run_interval(
+    client: &mut Herdr,
+    labels: &Labels,
+    config: &Config,
+    interval_ms: u64,
+) -> crate::Result<()> {
     install_quit_hook()?;
 
     let mut out = io::stdout();
     write!(out, "\x1b[?25l")?; // hide cursor
     out.flush()?;
 
+    // The tier cannot change while we run, so it is resolved once; the charge
+    // does change, so it is re-read once per frame — but only once, not once
+    // per space.
+    let icons = config.icon_set();
     let mut window_ms = FIRST_FRAME_WINDOW_MS;
     loop {
+        let battery = config.battery_reading();
         // On success, `snapshot` paces the loop via its internal
         // `thread::sleep(window_ms)` inside `measure`; on the error path it
         // returns before `measure`, so this frame has no delay of its own and
         // must sleep the cadence itself to avoid busy-spinning (mirrors the
         // daemon's error-branch sleep).
         let (body, failed) = match collect::snapshot(client, window_ms) {
-            Ok(spaces) => (render(&spaces, labels), false),
+            Ok(spaces) => (render(&spaces, labels, icons, battery), false),
             Err(err) => (
                 format!("{} {err}", Style::detect().red("  herdr unavailable:")),
                 true,
@@ -370,7 +530,12 @@ mod tests {
         }
     }
 
-    // ---- fmt_ram: MB below 1024, GB at/above ---------------------------------
+    /// Terse [`Battery`] builder for the cell tests.
+    fn bat(percent: f64, state: State) -> Battery {
+        Battery { percent, state }
+    }
+
+    // ---- fmt_ram / compact_ram: MB below 1024, GB at/above -------------------
 
     #[test]
     fn fmt_ram_switches_unit_at_1024() {
@@ -379,6 +544,74 @@ mod tests {
         assert_eq!(fmt_ram(1023.9), "1024 MB"); // still MB below the 1024 gate
         assert_eq!(fmt_ram(1024.0), "1.00 GB");
         assert_eq!(fmt_ram(1536.0), "1.50 GB");
+    }
+
+    #[test]
+    fn compact_ram_switches_unit_at_1024() {
+        assert_eq!(compact_ram(0.0), "0M");
+        assert_eq!(compact_ram(512.6), "513M"); // rounds to whole MB
+        assert_eq!(compact_ram(1023.4), "1023M"); // still MB below the gate
+        assert_eq!(compact_ram(1024.0), "1.0G");
+        assert_eq!(compact_ram(1536.0), "1.5G");
+    }
+
+    // ---- narrow metric cells --------------------------------------------------
+
+    #[test]
+    fn ram_cell_rounds_exactly_as_ram_pct_does() {
+        // The pre-icons sidebar showed `proc::ram_pct`, so the Text tier has to
+        // reproduce it byte for byte — these are that function's own cases.
+        assert_eq!(ram_cell_of(IconSet::Text, "ram", 1024.0, 16384.0), "ram 6%");
+        // 100 * 250 / 10000 = 2.5 -> 3 (half away from zero).
+        assert_eq!(ram_cell_of(IconSet::Text, "ram", 250.0, 10000.0), "ram 3%");
+        // The tier decorates that same number, it does not change it.
+        assert_eq!(
+            ram_cell_of(IconSet::Unicode, "ram", 1024.0, 16384.0),
+            "ram ░6%",
+        );
+    }
+
+    #[test]
+    fn ram_cell_falls_back_to_the_compact_absolute_without_a_total() {
+        // No MemTotal means no scale to be a percentage of. The absolute is
+        // shown with the label and *no* gauge: a gauge glyph claims a level, and
+        // in this branch we have none to claim.
+        assert_eq!(
+            ram_cell_of(IconSet::Unicode, "ram", 1536.0, 0.0),
+            "ram 1.5G"
+        );
+        assert_eq!(ram_cell_of(IconSet::Text, "ram", 512.0, 0.0), "ram 512M");
+        // Same for a nonsensical total, which would otherwise divide by zero.
+        assert_eq!(ram_cell_of(IconSet::Emoji, "ram", 0.0, -1.0), "ram 0M");
+    }
+
+    #[test]
+    fn metric_row_omits_an_absent_battery_and_its_separator() {
+        let cells = |battery: Option<&str>| {
+            metric_row(
+                "A".to_string(),
+                "B".to_string(),
+                battery.map(str::to_string),
+            )
+        };
+        assert_eq!(cells(None), "A · B"); // no dangling separator
+        assert_eq!(cells(Some("C")), "A · B · C");
+    }
+
+    #[test]
+    fn usage_row_is_cpu_then_ram_then_battery() {
+        // The whole row, spelled out with the machine total pinned (1310.72 MB
+        // of 16384 MB is 8%) — `usage_row` itself reads that total from the host.
+        let row = metric_row(
+            IconSet::Unicode.cpu("cpu", 26.0),
+            ram_cell_of(IconSet::Unicode, "ram", 1310.72, 16384.0),
+            battery_cell(
+                IconSet::Unicode,
+                &Labels::default(),
+                Some(bat(74.0, State::Discharging)),
+            ),
+        );
+        assert_eq!(row, "cpu ░26% · ram ░8% · bat ▓74%");
     }
 
     // ---- Style: gating + CPU thresholds --------------------------------------
@@ -405,7 +638,7 @@ mod tests {
 
     #[test]
     fn render_empty_spaces() {
-        let out = render_styled(&[], &Labels::default(), &plain());
+        let out = render_styled(&[], &Labels::default(), IconSet::Unicode, None, &plain());
         assert_eq!(out, "  CPU / RAM per space\n\n  No spaces open.");
     }
 
@@ -413,7 +646,13 @@ mod tests {
     fn render_lays_out_marker_branch_and_notes() {
         let mut focused = space("main", true, 5.0, 512.0, 2);
         focused.branch = "feature/x".to_string();
-        let out = render_styled(&[focused], &Labels::default(), &plain());
+        let out = render_styled(
+            &[focused],
+            &Labels::default(),
+            IconSet::Unicode,
+            None,
+            &plain(),
+        );
         let lines: Vec<&str> = out.split('\n').collect();
 
         assert_eq!(lines[0], "  CPU / RAM per space");
@@ -432,6 +671,8 @@ mod tests {
         let out = render_styled(
             &[space("s", false, 0.0, 0.0, 1)],
             &Labels::default(),
+            IconSet::Unicode,
+            None,
             &plain(),
         );
         let lines: Vec<&str> = out.split('\n').collect();
@@ -444,7 +685,7 @@ mod tests {
     fn render_shows_worktree_note() {
         let mut sp = space("repo", false, 0.0, 0.0, 3);
         sp.worktree_labels = Some(vec!["wt-a".to_string(), "wt-b".to_string()]);
-        let out = render_styled(&[sp], &Labels::default(), &plain());
+        let out = render_styled(&[sp], &Labels::default(), IconSet::Unicode, None, &plain());
         assert!(out.contains("· 3 panes · +2 worktrees"), "{out}");
     }
 
@@ -453,10 +694,64 @@ mod tests {
         let labels = Labels {
             cpu: "CPU".to_string(),
             ram: "MEM".to_string(),
+            battery: "PWR".to_string(),
         };
-        let out = render_styled(&[space("s", false, 1.0, 1.0, 1)], &labels, &plain());
+        let out = render_styled(
+            &[space("s", false, 1.0, 1.0, 1)],
+            &labels,
+            IconSet::Text,
+            Some(bat(74.0, State::Discharging)),
+            &plain(),
+        );
         assert!(out.contains("CPU"));
         assert!(out.contains("MEM"));
+        assert!(out.contains("PWR 74%"), "{out}");
+    }
+
+    // ---- render: the machine-wide battery lives on the total line ------------
+
+    #[test]
+    fn render_puts_the_battery_on_the_total_line_only() {
+        let spaces = [
+            space("a", true, 1.0, 1.0, 1),
+            space("b", false, 2.0, 2.0, 1),
+        ];
+        let out = render_styled(
+            &spaces,
+            &Labels::default(),
+            IconSet::Unicode,
+            Some(bat(74.0, State::Discharging)),
+            &plain(),
+        );
+        let lines: Vec<&str> = out.split('\n').collect();
+        let total = lines.last().expect("a total line");
+
+        assert!(total.contains("bat ▓74%"), "total: {total}");
+        // Two spaces, one battery: a machine-wide number copied onto every row
+        // would read as if each space had its own pack.
+        assert_eq!(out.matches("bat").count(), 1, "{out}");
+    }
+
+    #[test]
+    fn render_without_a_battery_is_the_report_unchanged() {
+        // The cell is additive — a battery-less host gets byte-for-byte the
+        // report this plugin printed before the metric existed.
+        let spaces = [space("a", true, 1.0, 1.0, 1)];
+        let with = render_styled(
+            &spaces,
+            &Labels::default(),
+            IconSet::Unicode,
+            Some(bat(74.0, State::Discharging)),
+            &plain(),
+        );
+        let without = render_styled(
+            &spaces,
+            &Labels::default(),
+            IconSet::Unicode,
+            None,
+            &plain(),
+        );
+        assert_eq!(with.strip_suffix("   bat ▓74%"), Some(without.as_str()));
     }
 
     // ---- json: number shape + field ordering ---------------------------------
@@ -478,9 +773,10 @@ mod tests {
         a.worktree_labels = Some(vec!["child".to_string()]);
         let b = space("w2", false, 0.0, 0.0, 1); // no worktrees
 
-        let out = render_json(&[a, b]);
+        let out = render_json(&[a, b], Some(bat(74.0, State::Discharging)));
 
-        // Keys appear in the declared order.
+        // Keys appear in the declared order. The battery pair is appended at the
+        // END: every key an existing consumer reads keeps the position it had.
         let order = [
             "workspace_id",
             "label",
@@ -492,6 +788,8 @@ mod tests {
             "ram_mb",
             "ram_percent",
             "includes_worktrees",
+            "battery_percent",
+            "battery_state",
         ];
         let mut last = 0;
         for key in order {
@@ -513,10 +811,62 @@ mod tests {
         // ram_percent is always present (number or null), never dropped.
         assert!(parsed[0].get("ram_percent").is_some());
         assert!(parsed[1].get("ram_percent").is_some());
+        // The battery is machine-wide, so every row carries the same reading —
+        // there is no per-space wrapper to hang it off without breaking the
+        // top-level array every consumer already parses.
+        for row in [&parsed[0], &parsed[1]] {
+            assert_eq!(row["battery_percent"], 74.0);
+            assert_eq!(row["battery_state"], "discharging");
+        }
+    }
+
+    #[test]
+    fn json_battery_pair_is_null_without_a_reading() {
+        // A desktop (and a user who set `battery = false`) emits the keys as
+        // `null` rather than dropping them — same rule `ram_percent` follows, so
+        // a consumer can read the field unconditionally.
+        let out = render_json(&[space("w1", true, 1.0, 1.0, 1)], None);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(parsed[0]["battery_percent"].is_null(), "{out}");
+        assert!(parsed[0]["battery_state"].is_null(), "{out}");
+        assert!(out.contains("\"battery_percent\": null"), "{out}");
+    }
+
+    #[test]
+    fn json_battery_state_is_lowercase_for_every_state() {
+        // The wire spelling is a contract: consumers match on these strings.
+        let expected = [
+            (State::Charging, "charging"),
+            (State::Discharging, "discharging"),
+            (State::Full, "full"),
+            (State::NotCharging, "not_charging"),
+            (State::Unknown, "unknown"),
+        ];
+        for (state, key) in expected {
+            assert_eq!(battery_state_key(state), key);
+            let out = render_json(&[space("w1", true, 0.0, 0.0, 1)], Some(bat(5.0, state)));
+            let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+            assert_eq!(parsed[0]["battery_state"], key, "{out}");
+        }
+    }
+
+    #[test]
+    fn json_battery_percent_rounds_like_every_other_number() {
+        let out = render_json(
+            &[space("w1", true, 0.0, 0.0, 1)],
+            Some(bat(63.46, State::Full)),
+        );
+        // 63.46 -> 63.5, and a whole percentage still collapses to an integer.
+        assert!(out.contains("\"battery_percent\": 63.5"), "{out}");
+        let whole = render_json(
+            &[space("w1", true, 0.0, 0.0, 1)],
+            Some(bat(100.0, State::Full)),
+        );
+        assert!(whole.contains("\"battery_percent\": 100,"), "{whole}");
     }
 
     #[test]
     fn json_empty_payload_is_bare_brackets() {
-        assert_eq!(render_json(&[]), "[]");
+        assert_eq!(render_json(&[], None), "[]");
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -17,7 +17,7 @@ use serde_json::Number;
 
 use crate::battery::{Battery, State};
 use crate::collect;
-use crate::config::{Config, Labels};
+use crate::config::{Config, Labels, DEFAULT_RAM_LABEL};
 use crate::herdr::Herdr;
 use crate::icons::IconSet;
 use crate::model::Space;
@@ -122,7 +122,7 @@ const CELL_SEPARATOR: &str = " · ";
 /// tier deliberately contributes nothing in that branch: a gauge glyph measures
 /// a level, and drawing one beside an absolute figure would be inventing a
 /// reading we do not have.
-fn ram_cell(icons: IconSet, label: &str, mb: f64) -> String {
+fn ram_cell(icons: IconSet, label: Option<&str>, mb: f64) -> String {
     ram_cell_of(icons, label, mb, proc::mem_total_mb())
 }
 
@@ -131,13 +131,16 @@ fn ram_cell(icons: IconSet, label: &str, mb: f64) -> String {
 /// The seam exists for the tests: the real total is read once and cached for the
 /// process, so a test host with a readable `/proc/meminfo` could never reach the
 /// fallback branch (and one without it could never reach the percent branch).
-fn ram_cell_of(icons: IconSet, label: &str, mb: f64, mem_total_mb: f64) -> String {
+fn ram_cell_of(icons: IconSet, label: Option<&str>, mb: f64, mem_total_mb: f64) -> String {
     if mem_total_mb > 0.0 {
         // Same arithmetic and rounding as `proc::ram_pct`, so the Text tier
         // reproduces the pre-icons sidebar byte for byte.
         icons.ram(label, 100.0 * mb / mem_total_mb)
     } else {
-        format!("{label} {}", compact_ram(mb))
+        // No total to be a percent OF, so the tier contributes nothing: a gauge
+        // glyph measures a level, and drawing one beside an absolute figure
+        // would invent a reading we do not have.
+        format!("{} {}", label.unwrap_or(DEFAULT_RAM_LABEL), compact_ram(mb))
     }
 }
 
@@ -148,7 +151,7 @@ fn ram_cell_of(icons: IconSet, label: &str, mb: f64, mem_total_mb: f64) -> Strin
 /// like. `reading` is already `None` when the user turned the metric off — see
 /// [`Config::battery_reading`].
 fn battery_cell(icons: IconSet, labels: &Labels, reading: Option<Battery>) -> Option<String> {
-    reading.map(|reading| icons.battery(&labels.battery, reading))
+    reading.map(|reading| icons.battery(labels.battery(), reading))
 }
 
 /// Join the cells of one narrow row: `cpu ░26% · ram ░8% · bat ▓74%`.
@@ -177,8 +180,8 @@ pub fn usage_row(
     battery: Option<Battery>,
 ) -> String {
     metric_row(
-        icons.cpu(&labels.cpu, cpu),
-        ram_cell(icons, &labels.ram, ram_mb),
+        icons.cpu(labels.cpu(), cpu),
+        ram_cell(icons, labels.ram(), ram_mb),
         battery_cell(icons, labels, battery),
     )
 }
@@ -257,9 +260,9 @@ fn render_styled(
         lines.push(format!("      {}", style.dim(branch)));
         lines.push(format!(
             "      {} {}   {} {}{}   {}",
-            labels.cpu,
+            labels.cpu_word(),
             cpu_str,
-            labels.ram,
+            labels.ram_word(),
             ram_cell,
             pct_str,
             style.dim(&notes.join(" ")),
@@ -280,9 +283,9 @@ fn render_styled(
         .unwrap_or_default();
     lines.push(style.dim(&format!(
         "  ── total   {} {:.1}%   {} {}{}{}",
-        labels.cpu,
+        labels.cpu_word(),
         total_cpu,
-        labels.ram,
+        labels.ram_word(),
         fmt_ram(total_ram),
         total_pct_str,
         total_battery_str,
@@ -561,12 +564,12 @@ mod tests {
     fn ram_cell_rounds_exactly_as_ram_pct_does() {
         // The pre-icons sidebar showed `proc::ram_pct`, so the Text tier has to
         // reproduce it byte for byte — these are that function's own cases.
-        assert_eq!(ram_cell_of(IconSet::Text, "ram", 1024.0, 16384.0), "ram 6%");
+        assert_eq!(ram_cell_of(IconSet::Text, None, 1024.0, 16384.0), "ram 6%");
         // 100 * 250 / 10000 = 2.5 -> 3 (half away from zero).
-        assert_eq!(ram_cell_of(IconSet::Text, "ram", 250.0, 10000.0), "ram 3%");
+        assert_eq!(ram_cell_of(IconSet::Text, None, 250.0, 10000.0), "ram 3%");
         // The tier decorates that same number, it does not change it.
         assert_eq!(
-            ram_cell_of(IconSet::Unicode, "ram", 1024.0, 16384.0),
+            ram_cell_of(IconSet::Unicode, None, 1024.0, 16384.0),
             "ram ░6%",
         );
     }
@@ -576,13 +579,10 @@ mod tests {
         // No MemTotal means no scale to be a percentage of. The absolute is
         // shown with the label and *no* gauge: a gauge glyph claims a level, and
         // in this branch we have none to claim.
-        assert_eq!(
-            ram_cell_of(IconSet::Unicode, "ram", 1536.0, 0.0),
-            "ram 1.5G"
-        );
-        assert_eq!(ram_cell_of(IconSet::Text, "ram", 512.0, 0.0), "ram 512M");
+        assert_eq!(ram_cell_of(IconSet::Unicode, None, 1536.0, 0.0), "ram 1.5G");
+        assert_eq!(ram_cell_of(IconSet::Text, None, 512.0, 0.0), "ram 512M");
         // Same for a nonsensical total, which would otherwise divide by zero.
-        assert_eq!(ram_cell_of(IconSet::Emoji, "ram", 0.0, -1.0), "ram 0M");
+        assert_eq!(ram_cell_of(IconSet::Emoji, None, 0.0, -1.0), "ram 0M");
     }
 
     #[test]
@@ -603,8 +603,8 @@ mod tests {
         // The whole row, spelled out with the machine total pinned (1310.72 MB
         // of 16384 MB is 8%) — `usage_row` itself reads that total from the host.
         let row = metric_row(
-            IconSet::Unicode.cpu("cpu", 26.0),
-            ram_cell_of(IconSet::Unicode, "ram", 1310.72, 16384.0),
+            IconSet::Unicode.cpu(None, 26.0),
+            ram_cell_of(IconSet::Unicode, None, 1310.72, 16384.0),
             battery_cell(
                 IconSet::Unicode,
                 &Labels::default(),
@@ -691,11 +691,7 @@ mod tests {
 
     #[test]
     fn render_honours_custom_labels() {
-        let labels = Labels {
-            cpu: "CPU".to_string(),
-            ram: "MEM".to_string(),
-            battery: "PWR".to_string(),
-        };
+        let labels = Labels::new(Some("CPU"), Some("MEM"), Some("PWR"));
         let out = render_styled(
             &[space("s", false, 1.0, 1.0, 1)],
             &labels,


### PR DESCRIPTION
Closes #1.

Adds the battery indicator asked for in #1, next to cpu and ram in the spaces
card — and hides it completely on a machine that has none, so desktops, servers
and VMs see nothing rather than a fabricated `0%`.

```
cpu ░26% · ram ░8% · bat ▓74%+     74%, charging
cpu ░26% · ram ░8% · bat ▒52%      52%, on battery
cpu ░26% · ram ░8%                 no battery in this machine
```

## Icons: what the request implied, and what is actually possible

The ask was for icons by default, if that could ship without users installing a
font. **It cannot — for real pictograms.** That is measured, not assumed:

- `U+1F50B` (🔋) is absent from **both** DejaVu Sans Mono and Liberation Mono,
  the default Linux mono faces (`fc-list :charset=1f50b` → no hits). Emoji are
  also double-width, which shears a narrow sidebar.
- Nerd Font glyphs are Private Use Area by definition.

So the default is a **level gauge** rather than a pictogram: `░` <34, `▒` <67,
`▓` <90, `█` ≥90. Every glyph the safe tiers emit was checked with
`fc-list :charset=<cp>` against both faces and is present in both. Glyphs present
in only one (`▣ ▤ ▮ ▯ ▰ ▱ ⚡`) are deliberately excluded.

| tier | renders | needs |
|---|---|---|
| `text` | `cpu 26% · ram 8% · bat 74%` | nothing |
| `unicode` (default via `auto`) | `cpu ░26% · ram ░8% · bat ▓74%` | nothing |
| `nerdfont` | pictograms | a Nerd Font |
| `emoji` | pictograms | a colour emoji font |

A guard test asserts the safe tiers stay inside the BMP, outside the PUA, and on
the measured allowlist, so the "no font install" promise cannot rot. It was
**mutation-tested** by swapping in `U+25B0`, which fails it as intended.

Because whether *your* font has these glyphs is not something the program can
answer, there is a new **Preview icon tiers** action (`--icons`) that draws all
four so you can pick by eye.

## macOS support

macOS previously fell into the `#[cfg(unix)]` `/proc` branch, so CPU and RAM
silently read **zero** on Darwin. `src/proc_macos.rs` is the third twin of the
process reader, on libproc. No new dependencies — `libc` 0.2 already exports all
of it. `clk_tck()` returns 1e9 there (nanoseconds), which is what keeps
`collect::measure` platform-neutral alongside Linux's 100 and Windows' 1e7.

Manifest is now `platforms = ["linux", "macos", "windows"]`.

## Notes

- Battery is read **once per refresh**, not per space — it is one value for the
  whole machine, so per-space reads would re-walk sysfs (or fork `pmset`) once
  per space to be told the same thing.
- `battery = false` gates at the *read*, so opting out costs zero syscalls and
  every surface is off by construction rather than by four checks that could
  drift. It also nulls the JSON keys; say so if you would rather JSON always
  reported.
- On Linux a wireless mouse registers as `type=Battery` with `scope=Device`;
  those are filtered out so your mouse is never reported as the machine's
  battery.
- herdr has no machine-wide sidebar row, so one battery reading is drawn once per
  space card. The full-width `--once` report avoids this by putting it on the
  total line only.
- JSON gains `battery_percent` / `battery_state` as **trailing** keys, so the
  documented key-order contract holds and existing consumers are unaffected.
- Also removes a stray `</content></invoke>` that has been rendering at the
  bottom of the published README since v1.0.0.

## Verification

| Gate | Result |
|---|---|
| fmt / clippy `-D warnings` / release build | clean |
| Tests | **147** (from 63 at branch point) |
| CI ubuntu-latest | green, 147 |
| CI windows-latest | green, 147 |
| CI macos-latest | green, **151** |

macOS runs 4 more tests than the others: `#[cfg(target_os = "macos")]` assertions
against the live process (`pid_listing_finds_us_and_launchd`,
`scan_includes_our_own_process_with_parent_and_cpu_time`, `own_rss_is_positive`,
`machine_ram_total_is_positive`). Those are runtime proof the libproc FFI works,
not just that it compiles.

**Linux end-to-end against herdr 0.8.0:**
- No battery on the test host: cell absent from `--once`, both JSON keys `null`.
- With a fixture sysfs tree: `bat ▓74%+` on the total line, `battery_percent: 74`
  and `battery_state: "charging"` in JSON.
- That tree also held a `scope=Device` mouse at 40% and a `type=Mains` adapter.
  Output was **74% — not 40%, and not an averaged 57%**, proving the filters work
  in the shipped binary and not only in unit tests.
- The `icons` action runs through herdr, exit 0, all four tiers.

**Not verified, and needs a human:** live macOS and Windows runs against a real
herdr. CI proves compilation and runtime FFI; it does not prove the sidebar
renders correctly on those platforms.