### PR TITLE
feat: a ram_display choice and plugin-side cpu/ram label overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "space-usage"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "libc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "space-usage"
-version = "1.9.0"
+version = "1.10.0"
 edition = "2021"
 description = "CPU and RAM usage per herdr space, grouped under the branch name."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ interval_seconds = 5        # 1..28800; statuses get a TTL of three intervals
 window_title_totals = true
 battery = true              # machine-wide cell on the title/report, not the rows
 icons = "auto"              # auto | text | unicode | nerdfont | emoji
+ram_display = "percent"     # or "gb" — always the compact absolute (513M / 1.5G)
 ```
 
 - **sidebar** (default): renders usage inside each spaces card, under the branch
@@ -344,6 +345,24 @@ every `herdr server reload-config` report
 renders a battery, so there is no second surface to keep in step. `cpu_label`
 and `ram_label` live in herdr's config precisely because the header does share
 them.
+
+**No header to share with?** On a stock (unpatched) build herdr draws no
+system-usage header, so `cpu_label` / `ram_label` are not keys it knows either —
+they still work from herdr's `[ui]`, but `herdr config check` and every reload
+flag them as unknown, the same noise that moved `battery_label` out. For that
+case the plugin's own `config.toml` accepts the same two keys, each overriding
+the herdr-side value only when set:
+
+```toml
+cpu_label = "C"
+ram_label = ""          # empty = name nothing: just the figure
+```
+
+Unlike herdr's file, where a blank label reads as unset (see below), nothing
+ships these plugin keys as blank templates — an empty value here is honoured as
+the deliberate "name nothing". Leave a key out to keep herdr's value; on a
+patched build, remember the header follows only the herdr-side keys, so
+overriding here lets the two surfaces name things differently.
 
 **Applying a change.** The updater re-reads both files every refresh, so the
 rows follow within one interval — no `status-toggle` needed. herdr's header

--- a/README.md
+++ b/README.md
@@ -394,8 +394,10 @@ this plugin anyway. On a **patched** build it does matter — the header follows
 only the herdr-side keys, so setting them here deliberately lets the two
 surfaces name things differently. Leave a key out to keep herdr's value.
 
-**Empty means "name nothing" in this file.** All three plugin-side labels read a
-blank as the deliberate bare number — no word, no glyph, no stray space:
+### Empty means "name nothing" in this file
+
+All three plugin-side labels read a blank as the deliberate bare number — no
+word, no glyph, no stray space:
 
 ```toml
 cpu_label = ""

--- a/README.md
+++ b/README.md
@@ -170,13 +170,40 @@ interval_seconds = 5        # 1..28800; statuses get a TTL of three intervals
 window_title_totals = true
 battery = true              # machine-wide cell on the title/report, not the rows
 icons = "auto"              # auto | text | unicode | nerdfont | emoji
-ram_display = "percent"     # or "gb" — always the compact absolute (513M / 1.5G)
+ram_display = "percent"     # or "gb" / "absolute" — see RAM as a figure
 ```
 
 - **sidebar** (default): renders usage inside each spaces card, under the branch
   name. Needs no patched build — see below.
 - **agents-panel**: each space gets its own entry in the sidebar agents panel via
   a `usage` pseudo-agent on a spare shell pane, carrying the usage token.
+
+### RAM as a figure, not a share
+
+`ram_display` decides what the **narrow** RAM cell shows — the sidebar rows and
+the window title:
+
+| value | cell | reads as |
+|---|---|---|
+| `percent` (default) | `ram 8%` | how much of this machine |
+| `gb` or `absolute` | `ram 1.5G` | the figure itself |
+
+Both spellings do the same thing, and case is ignored (`GB` works). The name
+`absolute` is the accurate one — the cell stays in MB below a gigabyte (`513M`)
+— while `gb` is what most people reach for.
+
+The percent answers "how much of this machine", which is usually the question.
+But on a box with memory to spare, a space using 1.5G reads as `2%`, which says
+almost nothing; the absolute is there for that.
+
+It changes only those narrow cells. The terminal report and the live dashboard
+already show both figures side by side (`1.5G (8%)`), and `--json` reports raw
+numbers, so neither has anything to switch.
+
+An absolute cell carries **no gauge** in the `unicode` tier: a gauge measures a
+level and this cell is not showing one. It keeps the tier's *name* though — the
+`nerdfont` and `emoji` glyphs still appear, because a glyph CPU cell beside the
+word `ram` is exactly the mismatch the tiers exist to prevent.
 
 Switching modes cleans up after the other mode automatically. The first run
 writes its `$usage` row into whichever table the mode renders from
@@ -322,47 +349,64 @@ Those two keys are the single point that changes both, because this plugin
 honours them too — and **an explicit label replaces the tier's glyph rather than
 stacking with it**, so you never get the icon drawn twice:
 
+The quotes below are where the tier's glyph goes — `space-usage --icons` prints
+the block already filled in for whichever tier you are previewing, so you can
+copy it straight across rather than hunting for the code points.
+
 ```toml
 # in herdr's own config.toml — drives BOTH the header and these rows
 [ui]
-cpu_label = ""
-ram_label = ""
+cpu_label = "<glyph>"
+ram_label = "<glyph>"
 ```
 
 ```toml
 # in the plugin's config.toml — battery only (title, report, JSON)
-battery_label = ""
+battery_label = "<glyph>"
 icons = "text"          # the labels are doing the naming now
 ```
 
-`space-usage --icons` prints the `[ui]` block for whichever tier you are
-previewing, so you can copy it straight across.
+Left genuinely empty, those two herdr-side keys read as *unset* (the tier names
+itself), while an empty `battery_label` here reads as "name nothing" — see
+[Empty means "name nothing"](#empty-means-name-nothing-in-this-file) below.
 
 **Why battery is in the other file:** herdr has no battery of its own to label,
 so `battery_label` is not a key it knows. Putting it in herdr's `[ui]` makes
 every `herdr server reload-config` report
 `unknown config key ui.battery_label; ignoring key`. Nothing outside this plugin
 renders a battery, so there is no second surface to keep in step. `cpu_label`
-and `ram_label` live in herdr's config precisely because the header does share
-them.
+and `ram_label` are herdr's own keys — it accepts both — and leaving them there
+is what keeps a patched build's header and these rows in step.
 
-**No header to share with?** On a stock (unpatched) build herdr draws no
-system-usage header, so `cpu_label` / `ram_label` are not keys it knows either —
-they still work from herdr's `[ui]`, but `herdr config check` and every reload
-flag them as unknown, the same noise that moved `battery_label` out. For that
-case the plugin's own `config.toml` accepts the same two keys, each overriding
-the herdr-side value only when set:
+**Naming only these rows.** If you would rather keep every plugin-only setting
+in the plugin's own file — next to `icons` and `battery_label` — its
+`config.toml` accepts `cpu_label` and `ram_label` too, each overriding the
+herdr-side value only when set:
 
 ```toml
 cpu_label = "C"
 ram_label = ""          # empty = name nothing: just the figure
 ```
 
-Unlike herdr's file, where a blank label reads as unset (see below), nothing
-ships these plugin keys as blank templates — an empty value here is honoured as
-the deliberate "name nothing". Leave a key out to keep herdr's value; on a
-patched build, remember the header follows only the herdr-side keys, so
-overriding here lets the two surfaces name things differently.
+On a stock build that changes nothing about what herdr draws: there is no
+system-usage header, so herdr's own `cpu_label` / `ram_label` reach nothing but
+this plugin anyway. On a **patched** build it does matter — the header follows
+only the herdr-side keys, so setting them here deliberately lets the two
+surfaces name things differently. Leave a key out to keep herdr's value.
+
+**Empty means "name nothing" in this file.** All three plugin-side labels read a
+blank as the deliberate bare number — no word, no glyph, no stray space:
+
+```toml
+cpu_label = ""
+ram_label = ""
+ram_display = "gb"      # a row of just the figures: `26% · 1.5G`
+```
+
+That is the opposite of herdr's file, where a blank reads as *unset* (see
+below), and the difference is in what ships: herdr ships those keys as blank
+commented templates, so a blank there is usually a line someone uncommented
+without filling in. Nothing ships them here.
 
 **Applying a change.** The updater re-reads both files every refresh, so the
 rows follow within one interval — no `status-toggle` needed. herdr's header

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -14,7 +14,7 @@
 
 id = "ez-corp.space-usage"
 name = "PC RAM & CPU Usage Overlay"
-version = "1.9.0"
+version = "1.10.0"
 # Oldest herdr with every API this plugin calls: `session.snapshot`, the `tokens`
 # metadata API on `pane.report_metadata` / `workspace.report_metadata`, and
 # `pane.process_info` — all 0.7.5. Diffing the two bundled API schemas

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,19 @@ impl Mode {
     }
 }
 
+/// How the narrow RAM cell renders its number (plugin `config.toml`
+/// `ram_display`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RamDisplay {
+    /// Percent of the machine's total, falling back to the compact absolute
+    /// form when the total is unreadable.
+    Percent,
+    /// Always the compact absolute form (`513M` / `1.5G`), even when a percent
+    /// could be computed — for readers who want the figure itself, not its
+    /// share of whatever this machine happens to have.
+    Absolute,
+}
+
 /// Plugin user config from `$HERDR_PLUGIN_CONFIG_DIR/config.toml`.
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -66,6 +79,9 @@ pub struct Config {
     /// gives it meaning, so an unknown value auto-detects instead of failing
     /// here.
     pub icons: String,
+    /// How the narrow RAM cell renders: percent of the machine's total (the
+    /// default), or always the compact absolute form.
+    pub ram_display: RamDisplay,
     /// Naming for the battery cell, overriding herdr's `[ui] battery_label`.
     ///
     /// Battery lives here rather than only in herdr's config because herdr has
@@ -73,13 +89,26 @@ pub struct Config {
     /// putting it in herdr's `[ui]` makes `herdr server reload-config` report
     /// `unknown config key ui.battery_label; ignoring key` on every reload.
     /// Harmless but noisy, and needless — nothing outside this plugin renders a
-    /// battery, so there is no second surface to keep in step. `cpu_label` and
-    /// `ram_label` stay in herdr's config precisely because the sidebar's
-    /// system-usage header does share those.
+    /// battery, so there is no second surface to keep in step.
     ///
     /// Names the battery wherever the plugin draws it: the window title, the
     /// report's total line, and the `--icons` preview.
     pub battery_label: Option<String>,
+    /// Per-key overrides for herdr's `[ui] cpu_label` / `ram_label`.
+    ///
+    /// Unset (the default) keeps herdr's config the single source of truth for
+    /// these two, which is what keeps a patched build's system-usage header and
+    /// these rows agreeing. Setting one here is for stock builds, where herdr
+    /// has no header and does not know the keys — putting them in herdr's
+    /// `[ui]` earns the same `unknown config key` noise on every reload that
+    /// moved `battery_label` into this file. The trade is explicit: a plugin
+    /// override names only what this plugin draws, so a header (if you later
+    /// run a patched build) will not follow it.
+    ///
+    /// Unlike the herdr-side keys, an EMPTY value here is not read as unset —
+    /// see [`parse_config`].
+    pub cpu_label: Option<String>,
+    pub ram_label: Option<String>,
 }
 
 impl Default for Config {
@@ -90,7 +119,10 @@ impl Default for Config {
             window_title_totals: true,
             battery: true,
             icons: "auto".to_string(),
+            ram_display: RamDisplay::Percent,
             battery_label: None,
+            cpu_label: None,
+            ram_label: None,
         }
     }
 }
@@ -177,10 +209,18 @@ impl Labels {
 
     /// Apply the plugin config's own label overrides on top of herdr's.
     ///
-    /// Only battery has one, for the reason given on [`Config::battery_label`].
-    /// Returning `Self` keeps the load-then-override pair a single expression at
-    /// each call site, so no caller can load the labels and forget the overrides.
+    /// Each key wins independently, so overriding one label does not detach the
+    /// others from herdr's config — see [`Config::battery_label`] and
+    /// [`Config::cpu_label`] for why each override exists. Returning `Self`
+    /// keeps the load-then-override pair a single expression at each call site,
+    /// so no caller can load the labels and forget the overrides.
     pub fn with_overrides(mut self, config: &Config) -> Self {
+        if let Some(label) = &config.cpu_label {
+            self.cpu = Some(label.clone());
+        }
+        if let Some(label) = &config.ram_label {
+            self.ram = Some(label.clone());
+        }
         if let Some(label) = &config.battery_label {
             self.battery = Some(label.clone());
         }
@@ -189,12 +229,22 @@ impl Labels {
 
     /// The word to print on surfaces that always spell one out regardless of
     /// tier — the full-width terminal report's columns and its total line.
+    ///
+    /// An empty label (the plugin config's "name nothing") falls back to the
+    /// default word here: the report's columns need a word to head them, and a
+    /// blank one would leave a bare figure floating in a wide table.
     pub fn cpu_word(&self) -> &str {
-        self.cpu().unwrap_or(DEFAULT_CPU_LABEL)
+        match self.cpu() {
+            Some(word) if !word.is_empty() => word,
+            _ => DEFAULT_CPU_LABEL,
+        }
     }
 
     pub fn ram_word(&self) -> &str {
-        self.ram().unwrap_or(DEFAULT_RAM_LABEL)
+        match self.ram() {
+            Some(word) if !word.is_empty() => word,
+            _ => DEFAULT_RAM_LABEL,
+        }
     }
 }
 
@@ -363,9 +413,10 @@ pub(crate) fn herdr_config_path() -> PathBuf {
 ///
 /// Recognised keys: `mode` (`agents-panel` | `sidebar`), `interval_seconds`
 /// (numeric `>= 1`), `window_title_totals` and `battery` (`false` only when
-/// they equal the literal `false`, any other value is truthy), and `icons`
-/// (a tier name kept verbatim for [`crate::icons::resolve`]). Unknown keys are
-/// ignored.
+/// they equal the literal `false`, any other value is truthy), `icons`
+/// (a tier name kept verbatim for [`crate::icons::resolve`]), `ram_display`
+/// (`percent` | `gb` | `absolute`), and the three label overrides. Unknown
+/// keys are ignored.
 fn parse_config(text: &str) -> Config {
     let mut cfg = Config::default();
     for line in text.split('\n') {
@@ -391,7 +442,23 @@ fn parse_config(text: &str) -> Config {
                 }
             }
             "window_title_totals" => cfg.window_title_totals = value != "false",
+            // `gb` is the name users reach for ("show it in GB"); `absolute` is
+            // what the setting actually does, since the cell stays in MB below
+            // a gigabyte. Both spellings land on the same behaviour.
+            "ram_display" if value == "gb" || value == "absolute" => {
+                cfg.ram_display = RamDisplay::Absolute
+            }
+            "ram_display" if value == "percent" => cfg.ram_display = RamDisplay::Percent,
             "battery_label" => cfg.battery_label = non_empty(value),
+            // Unlike the herdr-side labels, EMPTY is not read as unset here.
+            // The herdr rule exists because herdr ships those keys as blank
+            // commented templates, so a blank there is usually an accident.
+            // Nothing ships these two keys at all — writing `cpu_label = ""`
+            // in the plugin's own file can only be the deliberate "name
+            // nothing" that [`crate::icons::IconSet`] renders as the bare
+            // number.
+            "cpu_label" => cfg.cpu_label = Some(value.to_string()),
+            "ram_label" => cfg.ram_label = Some(value.to_string()),
             "battery" => cfg.battery = value != "false",
             // Stored raw: naming the tiers in two places would let the parser
             // and `icons::resolve` disagree about what `Nerd-Font` means.
@@ -693,6 +760,65 @@ mod tests {
         // With nothing set plugin-side, herdr's value still applies.
         let bare = Config::default();
         assert_eq!(from_herdr.with_overrides(&bare).battery(), Some("HERDR"));
+    }
+
+    #[test]
+    fn plugin_cpu_and_ram_label_overrides_win_per_key() {
+        // Each key overrides independently: naming one metric plugin-side must
+        // not detach the other from herdr's config.
+        let herdr = parse_herdr_labels("[ui]\ncpu_label = \"H\"\nram_label = \"R\"\n");
+        let cfg = parse_config("ram_label = 'M'\n");
+        let labels = herdr.with_overrides(&cfg);
+        assert_eq!(labels.cpu(), Some("H")); // untouched key keeps herdr's value
+        assert_eq!(labels.ram(), Some("M"));
+
+        let bare = parse_config("");
+        assert_eq!(bare.cpu_label, None);
+        assert_eq!(bare.ram_label, None);
+    }
+
+    #[test]
+    fn an_empty_plugin_label_is_name_nothing_not_unset() {
+        // The herdr-side blank-means-unset rule exists because herdr ships the
+        // keys as commented templates with empty quotes. Nothing ships these
+        // plugin keys at all, so an empty value here can only be deliberate —
+        // it reaches the renderer as the bare-number "name nothing".
+        let cfg = parse_config("cpu_label = \"\"\n");
+        assert_eq!(cfg.cpu_label.as_deref(), Some(""));
+        let labels = Labels::default().with_overrides(&cfg);
+        assert_eq!(labels.cpu(), Some(""));
+        assert_eq!(labels.ram(), None); // the other key stays unset
+
+        // Surfaces that always spell a word still get one — a wide report
+        // column headed by nothing would be a bare figure floating in a table.
+        assert_eq!(labels.cpu_word(), "cpu");
+    }
+
+    #[test]
+    fn ram_display_defaults_to_percent_and_ignores_unknown_values() {
+        assert_eq!(parse_config("").ram_display, RamDisplay::Percent);
+        assert_eq!(
+            parse_config("ram_display = \"both\"").ram_display,
+            RamDisplay::Percent
+        );
+    }
+
+    #[test]
+    fn ram_display_gb_and_absolute_both_select_the_absolute_form() {
+        // `gb` is what users reach for, `absolute` is what it does — the cell
+        // stays in MB below a gigabyte either way.
+        assert_eq!(
+            parse_config("ram_display = \"gb\"").ram_display,
+            RamDisplay::Absolute
+        );
+        assert_eq!(
+            parse_config("ram_display = \"absolute\"").ram_display,
+            RamDisplay::Absolute
+        );
+        assert_eq!(
+            parse_config("ram_display = \"percent\"").ram_display,
+            RamDisplay::Percent
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,15 +93,24 @@ pub struct Config {
     ///
     /// Names the battery wherever the plugin draws it: the window title, the
     /// report's total line, and the `--icons` preview.
+    ///
+    /// Unlike the herdr-side keys, an EMPTY value here is not read as unset —
+    /// see [`parse_config`].
     pub battery_label: Option<String>,
     /// Per-key overrides for herdr's `[ui] cpu_label` / `ram_label`.
     ///
     /// Unset (the default) keeps herdr's config the single source of truth for
     /// these two, which is what keeps a patched build's system-usage header and
-    /// these rows agreeing. Setting one here is for stock builds, where herdr
-    /// has no header and does not know the keys — putting them in herdr's
-    /// `[ui]` earns the same `unknown config key` noise on every reload that
-    /// moved `battery_label` into this file. The trade is explicit: a plugin
+    /// these rows agreeing. That default is the one to leave alone unless you
+    /// want the two surfaces to disagree.
+    ///
+    /// Setting one here is for the case herdr's config cannot express: naming
+    /// what THIS plugin draws without touching a key herdr also reads. On a
+    /// stock build herdr accepts `ui.cpu_label` / `ui.ram_label` but draws no
+    /// system-usage header of its own, so those keys reach nothing but this
+    /// plugin anyway — and some users would rather keep every plugin-only
+    /// setting in the plugin's own file, next to `icons` and `battery_label`,
+    /// than spread them across two configs. The trade is explicit: a plugin
     /// override names only what this plugin draws, so a header (if you later
     /// run a patched build) will not follow it.
     ///
@@ -415,8 +424,9 @@ pub(crate) fn herdr_config_path() -> PathBuf {
 /// (numeric `>= 1`), `window_title_totals` and `battery` (`false` only when
 /// they equal the literal `false`, any other value is truthy), `icons`
 /// (a tier name kept verbatim for [`crate::icons::resolve`]), `ram_display`
-/// (`percent` | `gb` | `absolute`), and the three label overrides. Unknown
-/// keys are ignored.
+/// (`percent` | `gb` | `absolute`, case-insensitive), and the three label
+/// overrides — `cpu_label`, `ram_label`, `battery_label` — where an empty value
+/// means "name nothing" rather than unset. Unknown keys are ignored.
 fn parse_config(text: &str) -> Config {
     let mut cfg = Config::default();
     for line in text.split('\n') {
@@ -444,19 +454,25 @@ fn parse_config(text: &str) -> Config {
             "window_title_totals" => cfg.window_title_totals = value != "false",
             // `gb` is the name users reach for ("show it in GB"); `absolute` is
             // what the setting actually does, since the cell stays in MB below
-            // a gigabyte. Both spellings land on the same behaviour.
-            "ram_display" if value == "gb" || value == "absolute" => {
-                cfg.ram_display = RamDisplay::Absolute
-            }
-            "ram_display" if value == "percent" => cfg.ram_display = RamDisplay::Percent,
-            "battery_label" => cfg.battery_label = non_empty(value),
-            // Unlike the herdr-side labels, EMPTY is not read as unset here.
-            // The herdr rule exists because herdr ships those keys as blank
-            // commented templates, so a blank there is usually an accident.
-            // Nothing ships these two keys at all — writing `cpu_label = ""`
-            // in the plugin's own file can only be the deliberate "name
-            // nothing" that [`crate::icons::IconSet`] renders as the bare
-            // number.
+            // a gigabyte. Both spellings land on the same behaviour, and case is
+            // folded because `icons` in this same file already forgives it —
+            // one file that accepts `Emoji` but not `GB` is a trap, not a rule.
+            "ram_display" => match value.trim().to_ascii_lowercase().as_str() {
+                "gb" | "absolute" => cfg.ram_display = RamDisplay::Absolute,
+                "percent" => cfg.ram_display = RamDisplay::Percent,
+                // Unknown spelling: keep the default rather than fail, matching
+                // how `mode` and `icons` treat a value they do not recognise.
+                _ => {}
+            },
+            // EMPTY is a deliberate "name nothing" for all three, NOT unset.
+            //
+            // This is the opposite of the herdr-side rule, and the difference is
+            // in what ships: herdr ships these keys as blank commented templates,
+            // so a blank there is usually someone uncommenting a line they have
+            // not filled in yet. Nothing ships them in the plugin's own file, so
+            // a blank here can only be the deliberate bare number that
+            // [`crate::icons::labelled`] renders.
+            "battery_label" => cfg.battery_label = Some(value.to_string()),
             "cpu_label" => cfg.cpu_label = Some(value.to_string()),
             "ram_label" => cfg.ram_label = Some(value.to_string()),
             "battery" => cfg.battery = value != "false",
@@ -792,6 +808,27 @@ mod tests {
         // Surfaces that always spell a word still get one — a wide report
         // column headed by nothing would be a bare figure floating in a table.
         assert_eq!(labels.cpu_word(), "cpu");
+
+        // Both words, not just cpu: the report has a RAM column with exactly the
+        // same blank-heading failure.
+        let ram = Labels::default().with_overrides(&parse_config("ram_label = \"\"\n"));
+        assert_eq!(ram.ram(), Some(""));
+        assert_eq!(ram.ram_word(), "ram");
+    }
+
+    #[test]
+    fn every_plugin_label_reads_an_empty_value_the_same_way() {
+        // One file, one rule. `battery_label` used to read a blank as unset
+        // while the other two read it as "name nothing", which made the same
+        // three characters mean opposite things three lines apart.
+        let cfg = parse_config("cpu_label = \"\"\nram_label = \"\"\nbattery_label = \"\"\n");
+        assert_eq!(cfg.cpu_label.as_deref(), Some(""));
+        assert_eq!(cfg.ram_label.as_deref(), Some(""));
+        assert_eq!(cfg.battery_label.as_deref(), Some(""));
+
+        // An absent key is still unset — that is the difference that matters.
+        let bare = parse_config("");
+        assert_eq!(bare.battery_label, None);
     }
 
     #[test]
@@ -799,6 +836,28 @@ mod tests {
         assert_eq!(parse_config("").ram_display, RamDisplay::Percent);
         assert_eq!(
             parse_config("ram_display = \"both\"").ram_display,
+            RamDisplay::Percent
+        );
+    }
+
+    #[test]
+    fn ram_display_forgives_case_and_quoting_the_way_icons_does() {
+        // `icons` in this same file folds case, so a file that took `Emoji` but
+        // silently ignored `GB` would be a trap rather than a rule.
+        for text in [
+            "ram_display = \"GB\"",
+            "ram_display = \"Gb\"",
+            "ram_display = \"ABSOLUTE\"",
+            "ram_display = gb", // unquoted is legal in this parser
+        ] {
+            assert_eq!(
+                parse_config(text).ram_display,
+                RamDisplay::Absolute,
+                "{text}"
+            );
+        }
+        assert_eq!(
+            parse_config("ram_display = \"PERCENT\"").ram_display,
             RamDisplay::Percent
         );
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -30,7 +30,7 @@ use std::time::Duration;
 
 use crate::battery::Battery;
 use crate::collect::{self, PSEUDO_AGENT};
-use crate::config::{self, Config, Labels, Mode, Wanted};
+use crate::config::{self, Config, Labels, Mode, RamDisplay, Wanted};
 use crate::herdr::{self, Herdr};
 use crate::herdr_config::{self, Change};
 use crate::icons::IconSet;
@@ -380,7 +380,7 @@ pub fn push_statuses(
     let ttl_ms = status_ttl_ms(config.interval_seconds);
 
     for sp in spaces {
-        let status = status_line(sp, labels, icons);
+        let status = status_line(sp, labels, icons, config.ram_display);
 
         if config.mode == Mode::AgentsPanel {
             // Drop stale claims from earlier runs so a space keeps one entry.
@@ -483,7 +483,13 @@ pub fn set_title_totals(
     labels: &Labels,
     icons: IconSet,
 ) {
-    let title = title_totals(spaces, labels, icons, config.battery_reading());
+    let title = title_totals(
+        spaces,
+        labels,
+        icons,
+        config.ram_display,
+        config.battery_reading(),
+    );
     let _ = client.window_title_set(&title);
 }
 
@@ -496,6 +502,7 @@ fn title_totals(
     spaces: &[Space],
     labels: &Labels,
     icons: IconSet,
+    ram_display: RamDisplay,
     battery: Option<Battery>,
 ) -> String {
     let mut cpu = 0.0;
@@ -506,7 +513,7 @@ fn title_totals(
     }
     format!(
         "spaces · {}",
-        render::totals_row(cpu, ram_mb, labels, icons, battery),
+        render::totals_row(cpu, ram_mb, labels, icons, ram_display, battery),
     )
 }
 
@@ -824,8 +831,8 @@ fn status_ttl_ms(interval_seconds: u64) -> u64 {
 /// No battery: it is one reading for the whole machine, so a copy of it on every
 /// space's row would read as if the space had its own. [`title_totals`] and the
 /// terminal report's total line are where it belongs — see [`render::usage_row`].
-fn status_line(sp: &Space, labels: &Labels, icons: IconSet) -> String {
-    render::usage_row(sp.cpu, sp.ram_mb, labels, icons)
+fn status_line(sp: &Space, labels: &Labels, icons: IconSet, ram_display: RamDisplay) -> String {
+    render::usage_row(sp.cpu, sp.ram_mb, labels, icons, ram_display)
 }
 
 /// Best-effort release of our pseudo-agent on `pane_id` (a closed pane errors and
@@ -920,14 +927,26 @@ mod tests {
         // The RAM cell depends on the host's MemTotal (percent when readable,
         // compact absolute when not), so assert the CPU rounding + label layout,
         // which are total-independent. `render::ram_cell_of` pins both branches.
-        let line = status_line(&space(5.6, 0.0), &labels, IconSet::Text);
+        let line = status_line(
+            &space(5.6, 0.0),
+            &labels,
+            IconSet::Text,
+            RamDisplay::Percent,
+        );
         assert!(line.starts_with("CPU 6% · MEM "), "got: {line}");
     }
 
     #[test]
     fn status_line_rounds_cpu_half_away_from_zero() {
         let labels = Labels::default();
-        let line = |cpu| status_line(&space(cpu, 0.0), &labels, IconSet::Text);
+        let line = |cpu| {
+            status_line(
+                &space(cpu, 0.0),
+                &labels,
+                IconSet::Text,
+                RamDisplay::Percent,
+            )
+        };
         assert!(line(2.5).starts_with("cpu 3%"));
         assert!(line(2.4).starts_with("cpu 2%"));
     }
@@ -944,12 +963,13 @@ mod tests {
         // whether this box has a pack does not change either side.
         let labels = Labels::default();
         let sp = space(26.0, 0.0);
-        let row = status_line(&sp, &labels, IconSet::Unicode);
+        let row = status_line(&sp, &labels, IconSet::Unicode, RamDisplay::Percent);
         let machine = render::totals_row(
             sp.cpu,
             sp.ram_mb,
             &labels,
             IconSet::Unicode,
+            RamDisplay::Percent,
             Some(bat(74.0, State::Discharging)),
         );
 
@@ -970,7 +990,7 @@ mod tests {
             (IconSet::Emoji, "💻26%"),
         ];
         for (icons, cpu) in expected {
-            let line = status_line(&sp, &labels, icons);
+            let line = status_line(&sp, &labels, icons, RamDisplay::Percent);
             assert!(line.starts_with(&format!("{cpu} · ")), "{icons:?}: {line}");
             // Each tier names the battery its own way, so check all three marks
             // against every row — a glyph tier smuggling one back in would slip
@@ -993,6 +1013,7 @@ mod tests {
                 &[space(26.0, 0.0)],
                 &labels,
                 IconSet::Unicode,
+                RamDisplay::Percent,
                 Some(bat(74.0, state)),
             )
         };
@@ -1010,9 +1031,10 @@ mod tests {
             &spaces,
             &labels,
             IconSet::Text,
+            RamDisplay::Percent,
             Some(bat(74.0, State::Full)),
         );
-        let without = title_totals(&spaces, &labels, IconSet::Text, None);
+        let without = title_totals(&spaces, &labels, IconSet::Text, RamDisplay::Percent, None);
 
         // 10.0 + 16.4 = 26.4, rounded once over the total rather than per space.
         assert!(with.starts_with("spaces · cpu 26% · ram "), "got: {with}");

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -937,6 +937,23 @@ mod tests {
     }
 
     #[test]
+    fn status_line_draws_the_absolute_ram_the_config_asked_for() {
+        // The sidebar row is where `ram_display` is actually read, and it is the
+        // one surface no other test reaches with `Absolute` — the row builders
+        // are pinned directly, but nothing proved the daemon hands the setting
+        // down. 1536 MB is `1.5G` whatever this host's MemTotal happens to be,
+        // which is exactly the point of the setting.
+        let labels = Labels::default();
+        let line = status_line(
+            &space(26.0, 1536.0),
+            &labels,
+            IconSet::Text,
+            RamDisplay::Absolute,
+        );
+        assert_eq!(line, "cpu 26% · ram 1.5G");
+    }
+
+    #[test]
     fn status_line_rounds_cpu_half_away_from_zero() {
         let labels = Labels::default();
         let line = |cpu| {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -30,13 +30,13 @@ use std::time::Duration;
 
 use crate::battery::Battery;
 use crate::collect::{self, PSEUDO_AGENT};
-use crate::config::{self, Config, Labels, Mode, RamDisplay, Wanted};
+use crate::config::{self, Config, Labels, Mode, Wanted};
 use crate::herdr::{self, Herdr};
 use crate::herdr_config::{self, Change};
 use crate::icons::IconSet;
 use crate::model::Space;
 use crate::proc;
-use crate::render;
+use crate::render::{self, RowStyle};
 
 /// Panes we have pushed status onto this run, so shutdown can clear them.
 #[derive(Debug, Default)]
@@ -59,6 +59,17 @@ struct Settings {
     config: Config,
     labels: Labels,
     icons: IconSet,
+}
+
+impl Settings {
+    /// This cycle's presentation, as the one value the row builders take.
+    ///
+    /// Borrows rather than clones the labels: the style lives inside a single
+    /// refresh, and the whole point of [`Settings`] is that there is one copy of
+    /// these to disagree about.
+    fn row_style(&self) -> RowStyle<'_> {
+        RowStyle::from_config(&self.labels, self.icons, &self.config)
+    }
 }
 
 /// Re-read the plugin config and herdr's labels, and re-resolve the icon tier.
@@ -191,7 +202,8 @@ pub fn run_daemon() -> crate::Result<()> {
         // the other. The interval is deliberately NOT re-read; changing the
         // cadence mid-flight would desynchronise the TTL from the refresh rate.
         settings = reload_settings();
-        let (config, labels, icons) = (&settings.config, &settings.labels, settings.icons);
+        let config = &settings.config;
+        let style = settings.row_style();
 
         // Reinstalled or rebuilt underneath us? Then this process is the old
         // version and nothing else will ever notice: herdr runs no hook on
@@ -216,13 +228,13 @@ pub fn run_daemon() -> crate::Result<()> {
                 }
                 {
                     let mut guard = tracked.lock().expect("tracked mutex poisoned");
-                    push_statuses(&mut client, &spaces, config, labels, icons, &mut guard);
+                    push_statuses(&mut client, &spaces, config, style, &mut guard);
                 }
                 // The title is the only surface here that draws a battery, so
                 // the read lives under its gate: a machine-wide reading nobody
                 // renders is a sysfs walk (or a `pmset` fork) for nothing.
                 if config.window_title_totals {
-                    set_title_totals(&mut client, &spaces, config, labels, icons);
+                    set_title_totals(&mut client, &spaces, config, style);
                 }
                 failures = 0;
             }
@@ -372,15 +384,14 @@ pub fn push_statuses(
     client: &mut Herdr,
     spaces: &[Space],
     config: &Config,
-    labels: &Labels,
-    icons: IconSet,
+    style: RowStyle,
     tracked: &mut Tracked,
 ) {
     let source = config::plugin_id();
     let ttl_ms = status_ttl_ms(config.interval_seconds);
 
     for sp in spaces {
-        let status = status_line(sp, labels, icons, config.ram_display);
+        let status = status_line(sp, style);
 
         if config.mode == Mode::AgentsPanel {
             // Drop stale claims from earlier runs so a space keeps one entry.
@@ -476,20 +487,8 @@ pub fn clear_all(client: &mut Herdr, tracked: &Tracked) {
 /// Takes the reading off the cycle's `config` rather than a battery argument:
 /// this is the one surface the daemon draws it on, so nothing else has to carry
 /// the value past a row that will not use it.
-pub fn set_title_totals(
-    client: &mut Herdr,
-    spaces: &[Space],
-    config: &Config,
-    labels: &Labels,
-    icons: IconSet,
-) {
-    let title = title_totals(
-        spaces,
-        labels,
-        icons,
-        config.ram_display,
-        config.battery_reading(),
-    );
+pub fn set_title_totals(client: &mut Herdr, spaces: &[Space], config: &Config, style: RowStyle) {
+    let title = title_totals(spaces, style, config.battery_reading());
     let _ = client.window_title_set(&title);
 }
 
@@ -498,13 +497,7 @@ pub fn set_title_totals(
 ///
 /// Pure, and split from [`set_title_totals`] so the formatting is testable
 /// without a live herdr connection.
-fn title_totals(
-    spaces: &[Space],
-    labels: &Labels,
-    icons: IconSet,
-    ram_display: RamDisplay,
-    battery: Option<Battery>,
-) -> String {
+fn title_totals(spaces: &[Space], style: RowStyle, battery: Option<Battery>) -> String {
     let mut cpu = 0.0;
     let mut ram_mb = 0.0;
     for sp in spaces {
@@ -513,7 +506,7 @@ fn title_totals(
     }
     format!(
         "spaces · {}",
-        render::totals_row(cpu, ram_mb, labels, icons, ram_display, battery),
+        render::totals_row(cpu, ram_mb, style, battery),
     )
 }
 
@@ -831,8 +824,8 @@ fn status_ttl_ms(interval_seconds: u64) -> u64 {
 /// No battery: it is one reading for the whole machine, so a copy of it on every
 /// space's row would read as if the space had its own. [`title_totals`] and the
 /// terminal report's total line are where it belongs — see [`render::usage_row`].
-fn status_line(sp: &Space, labels: &Labels, icons: IconSet, ram_display: RamDisplay) -> String {
-    render::usage_row(sp.cpu, sp.ram_mb, labels, icons, ram_display)
+fn status_line(sp: &Space, style: RowStyle) -> String {
+    render::usage_row(sp.cpu, sp.ram_mb, style)
 }
 
 /// Best-effort release of our pseudo-agent on `pane_id` (a closed pane errors and
@@ -852,7 +845,7 @@ fn notify(body: impl AsRef<str>) {
 mod tests {
     use super::*;
     use crate::battery::State;
-    use crate::config::Labels;
+    use crate::config::{Labels, RamDisplay};
 
     fn space(cpu: f64, ram_mb: f64) -> Space {
         Space {
@@ -919,6 +912,12 @@ mod tests {
         assert_eq!(status_ttl_ms(u64::MAX), MAX_TTL_MS);
     }
 
+    /// The plain-text style with default naming — what most of these tests want,
+    /// since they are asserting layout rather than glyphs.
+    fn text_style(labels: &Labels) -> RowStyle<'_> {
+        RowStyle::new(labels, IconSet::Text, RamDisplay::Percent)
+    }
+
     // ---- the sidebar status line --------------------------------------------
 
     #[test]
@@ -927,13 +926,29 @@ mod tests {
         // The RAM cell depends on the host's MemTotal (percent when readable,
         // compact absolute when not), so assert the CPU rounding + label layout,
         // which are total-independent. `render::ram_cell_of` pins both branches.
-        let line = status_line(
-            &space(5.6, 0.0),
-            &labels,
-            IconSet::Text,
-            RamDisplay::Percent,
-        );
+        let line = status_line(&space(5.6, 0.0), text_style(&labels));
         assert!(line.starts_with("CPU 6% · MEM "), "got: {line}");
+    }
+
+    #[test]
+    fn the_cycles_style_comes_from_the_cycles_config() {
+        // The last link in the chain: `reload_settings` re-reads the config every
+        // refresh, and `row_style` is what turns that into the value the row
+        // builders take. If it dropped `ram_display` on the floor, editing the
+        // config would change nothing on the sidebar and every other test here
+        // would still be green — they all build a style by hand.
+        let settings = Settings {
+            config: Config {
+                ram_display: RamDisplay::Absolute,
+                ..Config::default()
+            },
+            labels: Labels::default(),
+            icons: IconSet::Text,
+        };
+        assert_eq!(
+            status_line(&space(26.0, 1536.0), settings.row_style()),
+            "cpu 26% · ram 1.5G",
+        );
     }
 
     #[test]
@@ -944,26 +959,17 @@ mod tests {
         // down. 1536 MB is `1.5G` whatever this host's MemTotal happens to be,
         // which is exactly the point of the setting.
         let labels = Labels::default();
-        let line = status_line(
-            &space(26.0, 1536.0),
-            &labels,
-            IconSet::Text,
-            RamDisplay::Absolute,
+        let style = RowStyle::new(&labels, IconSet::Text, RamDisplay::Absolute);
+        assert_eq!(
+            status_line(&space(26.0, 1536.0), style),
+            "cpu 26% · ram 1.5G"
         );
-        assert_eq!(line, "cpu 26% · ram 1.5G");
     }
 
     #[test]
     fn status_line_rounds_cpu_half_away_from_zero() {
         let labels = Labels::default();
-        let line = |cpu| {
-            status_line(
-                &space(cpu, 0.0),
-                &labels,
-                IconSet::Text,
-                RamDisplay::Percent,
-            )
-        };
+        let line = |cpu| status_line(&space(cpu, 0.0), text_style(&labels));
         assert!(line(2.5).starts_with("cpu 3%"));
         assert!(line(2.4).starts_with("cpu 2%"));
     }
@@ -980,13 +986,12 @@ mod tests {
         // whether this box has a pack does not change either side.
         let labels = Labels::default();
         let sp = space(26.0, 0.0);
-        let row = status_line(&sp, &labels, IconSet::Unicode, RamDisplay::Percent);
+        let style = RowStyle::new(&labels, IconSet::Unicode, RamDisplay::Percent);
+        let row = status_line(&sp, style);
         let machine = render::totals_row(
             sp.cpu,
             sp.ram_mb,
-            &labels,
-            IconSet::Unicode,
-            RamDisplay::Percent,
+            style,
             Some(bat(74.0, State::Discharging)),
         );
 
@@ -1007,7 +1012,7 @@ mod tests {
             (IconSet::Emoji, "💻26%"),
         ];
         for (icons, cpu) in expected {
-            let line = status_line(&sp, &labels, icons, RamDisplay::Percent);
+            let line = status_line(&sp, RowStyle::new(&labels, icons, RamDisplay::Percent));
             assert!(line.starts_with(&format!("{cpu} · ")), "{icons:?}: {line}");
             // Each tier names the battery its own way, so check all three marks
             // against every row — a glyph tier smuggling one back in would slip
@@ -1025,15 +1030,8 @@ mod tests {
         // Same charge, three states: a glance at the title has to tell a pack
         // that is filling from one that is draining.
         let labels = Labels::default();
-        let line = |state| {
-            title_totals(
-                &[space(26.0, 0.0)],
-                &labels,
-                IconSet::Unicode,
-                RamDisplay::Percent,
-                Some(bat(74.0, state)),
-            )
-        };
+        let style = RowStyle::new(&labels, IconSet::Unicode, RamDisplay::Percent);
+        let line = |state| title_totals(&[space(26.0, 0.0)], style, Some(bat(74.0, state)));
         assert!(line(State::Charging).ends_with("bat ▓74%+"));
         assert!(line(State::Discharging).ends_with("bat ▓74%"));
         assert!(line(State::Full).ends_with("bat ▓74%="));
@@ -1044,14 +1042,9 @@ mod tests {
     fn title_totals_sums_the_spaces_and_carries_one_battery() {
         let labels = Labels::default();
         let spaces = [space(10.0, 0.0), space(16.4, 0.0)];
-        let with = title_totals(
-            &spaces,
-            &labels,
-            IconSet::Text,
-            RamDisplay::Percent,
-            Some(bat(74.0, State::Full)),
-        );
-        let without = title_totals(&spaces, &labels, IconSet::Text, RamDisplay::Percent, None);
+        let style = text_style(&labels);
+        let with = title_totals(&spaces, style, Some(bat(74.0, State::Full)));
+        let without = title_totals(&spaces, style, None);
 
         // 10.0 + 16.4 = 26.4, rounded once over the total rather than per space.
         assert!(with.starts_with("spaces · cpu 26% · ram "), "got: {with}");

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -189,6 +189,21 @@ impl IconSet {
         )
     }
 
+    /// Render RAM as a figure that is not a percentage — `ram 1.5G` in the
+    /// [`IconSet::Text`] tier, ` 1.5G` in [`IconSet::NerdFont`].
+    ///
+    /// Used where the cell shows an absolute rather than a share: no readable
+    /// `MemTotal` to be a percentage of, or `ram_display = "gb"` asking for the
+    /// figure itself. The tier still supplies its *name* — what it cannot supply
+    /// is a **gauge**, because a gauge measures a level and this cell is not
+    /// showing one. Those are two different jobs, and only the second one
+    /// depends on having a percentage: dropping the naming as well would put a
+    /// glyph CPU cell next to the word `ram` in the same row, which is exactly
+    /// the drift the tiers exist to prevent.
+    pub fn ram_absolute(self, label: Option<&str>, value: &str) -> String {
+        labelled(label, || self.naming(Metric::Ram, None), value)
+    }
+
     /// This tier's naming as herdr `[ui]` label values: `(cpu, ram, battery)`.
     ///
     /// Exists so [`herdr_ui_snippet`] can hand the user a block that pins the
@@ -220,44 +235,59 @@ impl IconSet {
     ) -> String {
         let mark = mark.map(String::from).unwrap_or_default();
         let number = format!("{}%{mark}", round_percent(percent));
+        labelled(label, || self.naming(metric, Some(percent)), &number)
+    }
 
-        // An explicit herdr `[ui]` label REPLACES the tier's naming — it does not
-        // stack on top of it.
-        //
-        // This is what makes those labels a genuine single source of truth. On a
-        // patched build the sidebar's system-usage header renders from the same
-        // two keys, so a user who sets `cpu_label` once gets the header and these
-        // rows agreeing no matter which tier is active. Prefixing the label to
-        // the tier's glyph instead would draw the icon twice for exactly the
-        // user who took the trouble to configure it.
-        //
-        // An empty label is a deliberate "name nothing": no word, no glyph, no
-        // stray leading space.
-        if let Some(label) = label {
-            return if label.is_empty() {
-                number
-            } else {
-                format!("{label} {number}")
-            };
-        }
-
-        // No explicit label, so the tier decides how the metric is named.
-        let naming = match self {
+    /// How this tier names `metric` when the user has chosen no label.
+    ///
+    /// `percent` is the reading the naming is *about*, and `None` means there is
+    /// no reading — the caller is drawing an absolute figure. Only the two parts
+    /// that measure a level care: the [`IconSet::Unicode`] gauge and the Nerd
+    /// Font battery ramp. Everything else is a name and is drawn either way.
+    fn naming(self, metric: Metric, percent: Option<f64>) -> String {
+        match self {
             IconSet::Text => format!("{} ", metric.default_word()),
             // The word still carries the meaning; the gauge runs straight into
-            // the number it measures.
-            IconSet::Unicode => format!(
-                "{} {}",
-                metric.default_word(),
-                ramp_pick(&GAUGE_RAMP, percent)
-            ),
+            // the number it measures. With no reading there is no level to
+            // gauge, so the word stands alone rather than inventing one.
+            IconSet::Unicode => match percent {
+                Some(percent) => format!(
+                    "{} {}",
+                    metric.default_word(),
+                    ramp_pick(&GAUGE_RAMP, percent)
+                ),
+                None => format!("{} ", metric.default_word()),
+            },
             // Nerd Font glyphs are drawn edge-to-edge in their cell; without the
-            // space the digits touch them.
-            IconSet::NerdFont => format!("{} ", metric.nerd_glyph(percent)),
+            // space the digits touch them. Only the battery family ramps, and it
+            // is never drawn without a reading, so the full-battery glyph is an
+            // unreachable stand-in rather than a claim about the charge.
+            IconSet::NerdFont => format!("{} ", metric.nerd_glyph(percent.unwrap_or(100.0))),
             // Emoji already occupy two columns — a space on top reads as a gap.
             IconSet::Emoji => metric.emoji().to_string(),
-        };
-        format!("{naming}{number}")
+        }
+    }
+}
+
+/// `[label ]<body>` — the one place the label rules live, for every tier, metric
+/// and cell shape.
+///
+/// An explicit label REPLACES the tier's naming rather than stacking on top of
+/// it. This is what makes those labels a genuine single source of truth: on a
+/// patched build the sidebar's system-usage header renders from the same
+/// `cpu_label` / `ram_label`, so a user who sets one once gets the header and
+/// these rows agreeing no matter which tier is active. Prefixing the label to
+/// the tier's glyph instead would draw the icon twice for exactly the user who
+/// took the trouble to configure it.
+///
+/// An empty label is a deliberate "name nothing": no word, no glyph, no stray
+/// leading space. `naming` is lazy because it is only consulted when no label
+/// was chosen — and it is the only part that differs between cell shapes.
+fn labelled(label: Option<&str>, naming: impl FnOnce() -> String, body: &str) -> String {
+    match label {
+        Some("") => body.to_string(),
+        Some(label) => format!("{label} {body}"),
+        None => format!("{}{body}", naming()),
     }
 }
 
@@ -830,6 +860,44 @@ mod tests {
             IconSet::Unicode.battery(None, bat(100.0, State::Full)),
             "bat █100%=",
         );
+    }
+
+    // ---- a figure that is not a percentage ---------------------------------------
+
+    #[test]
+    fn ram_absolute_names_the_metric_in_every_tier_but_gauges_in_none() {
+        // Two different jobs. Every tier still NAMES ram, because a row whose
+        // cpu cell is a glyph and whose ram cell is the word `ram` is the drift
+        // the tiers exist to prevent. No tier GAUGES it, because there is no
+        // level here to measure — the figure is an absolute.
+        assert_eq!(IconSet::Text.ram_absolute(None, "1.5G"), "ram 1.5G");
+        assert_eq!(IconSet::Unicode.ram_absolute(None, "1.5G"), "ram 1.5G");
+        assert_eq!(
+            IconSet::NerdFont.ram_absolute(None, "1.5G"),
+            format!("{NERD_RAM} 1.5G")
+        );
+        assert_eq!(
+            IconSet::Emoji.ram_absolute(None, "1.5G"),
+            format!("{EMOJI_RAM}1.5G")
+        );
+
+        // No gauge glyph anywhere, in any tier.
+        for set in ALL_TIERS {
+            let cell = set.ram_absolute(None, "1.5G");
+            for (_, glyph) in GAUGE_RAMP {
+                assert!(!cell.contains(glyph), "{set:?} gauged an absolute: {cell}");
+            }
+        }
+    }
+
+    #[test]
+    fn ram_absolute_honours_the_same_label_rules_as_a_percentage_cell() {
+        for set in ALL_TIERS {
+            // An explicit label replaces the naming...
+            assert_eq!(set.ram_absolute(Some("MEM"), "1.5G"), "MEM 1.5G", "{set:?}");
+            // ...and an empty one names nothing, with no stray leading space.
+            assert_eq!(set.ram_absolute(Some(""), "1.5G"), "1.5G", "{set:?}");
+        }
     }
 
     // ---- herdr label overrides --------------------------------------------------

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -3,12 +3,17 @@
 //! The sidebar row is only a few characters wide, so every glyph has to earn its
 //! column. Four tiers ladder up by how much they assume about the user's font:
 //!
-//! | tier | cpu | ram | battery | needs |
-//! |---|---|---|---|---|
-//! | [`IconSet::Text`] | `cpu 26%` | `ram 8%` | `bat 74%` | nothing |
-//! | [`IconSet::Unicode`] | `cpu ░26%` | `ram ░8%` | `bat ▓74%` | nothing |
-//! | [`IconSet::NerdFont`] | ` 26%` | ` 8%` | ` 74%` | a Nerd Font |
-//! | [`IconSet::Emoji`] | `💻26%` | `🧠8%` | `🔋74%` | a colour emoji font |
+//! | tier | cpu | ram | ram (absolute) | battery | needs |
+//! |---|---|---|---|---|---|
+//! | [`IconSet::Text`] | `cpu 26%` | `ram 8%` | `ram 1.5G` | `bat 74%` | nothing |
+//! | [`IconSet::Unicode`] | `cpu ░26%` | `ram ░8%` | `ram 1.5G` | `bat ▓74%` | nothing |
+//! | [`IconSet::NerdFont`] | ` 26%` | ` 8%` | ` 1.5G` | ` 74%` | a Nerd Font |
+//! | [`IconSet::Emoji`] | `💻26%` | `🧠8%` | `🧠1.5G` | `🔋74%` | a colour emoji font |
+//!
+//! The absolute column ([`IconSet::ram_absolute`]) is the same naming minus the
+//! gauge: a gauge measures a level, and that cell is not showing one. Only the
+//! [`IconSet::Unicode`] tier visibly loses anything, because its gauge was the
+//! only part doing the measuring.
 //!
 //! Only the first two are safe unprompted, and that claim is measured rather
 //! than assumed: every glyph they emit was checked with `fc-list :charset=<cp>`

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,14 @@ const ICON_TIERS: [(&str, icons::IconSet); 4] = [
 const SAMPLE_CPU: f64 = 26.0;
 /// Sample RAM share.
 const SAMPLE_RAM: f64 = 8.0;
+/// Sample RAM figure, and the machine total it is a share of.
+///
+/// The pair is chosen so `SAMPLE_RAM_MB` is exactly [`SAMPLE_RAM`] percent of
+/// `SAMPLE_MEM_TOTAL_MB` (1536 of 19200). That is what lets the preview draw the
+/// real cell for whichever `ram_display` is configured — `8%` or `1.5G` — and
+/// have both be the same reading rather than two unrelated samples.
+const SAMPLE_RAM_MB: f64 = 1536.0;
+const SAMPLE_MEM_TOTAL_MB: f64 = SAMPLE_RAM_MB * 100.0 / SAMPLE_RAM;
 /// Sample battery: mid-ramp, so the tiers that vary their glyph by charge show
 /// a middle one, and charging, so the `+` mark appears.
 const SAMPLE_BATTERY: battery::Battery = battery::Battery {
@@ -140,21 +148,38 @@ fn run() -> Result<()> {
 /// visible only to the person looking at the screen. So the preview shows the
 /// rows and lets them judge — a tier that comes out as boxes is one to avoid.
 ///
-/// The rows use the user's own herdr `[ui]` labels and go through the same
-/// [`render::metric_row`] every surface does, so what they see is what they get.
-/// All three metrics are drawn — a space's row is the first two cells, and the
-/// battery joins them on the window title and the report's total line.
+/// The rows use the user's own labels, the configured `ram_display`, and the
+/// same [`render::metric_row`] every surface does, so what they see is what they
+/// get. All three metrics are drawn — a space's row is the first two cells, and
+/// the battery joins them on the window title and the report's total line.
 fn print_icon_preview(config: &config::Config, labels: &config::Labels) {
     let current = config.icon_set();
     println!(
-        "\n  Icon tiers — {SAMPLE_CPU:.0}% cpu, {SAMPLE_RAM:.0}% ram, \
+        "\n  Icon tiers — {SAMPLE_CPU:.0}% cpu, {} ram, \
          {:.0}% battery charging, drawn by each tier:\n",
+        // Named the way the configured `ram_display` will name it in the rows.
+        render::ram_cell_of(
+            icons::IconSet::Text,
+            Some(""),
+            SAMPLE_RAM_MB,
+            config.ram_display,
+            SAMPLE_MEM_TOTAL_MB,
+        ),
         SAMPLE_BATTERY.percent,
     );
     for (name, set) in ICON_TIERS {
         let row = render::metric_row(
             set.cpu(labels.cpu(), SAMPLE_CPU),
-            set.ram(labels.ram(), SAMPLE_RAM),
+            // The real cell, not `set.ram`: `ram_display = "gb"` changes what a
+            // RAM cell looks like, and a preview that showed a percent the rows
+            // will never draw would be worse than no preview.
+            render::ram_cell_of(
+                set,
+                labels.ram(),
+                SAMPLE_RAM_MB,
+                config.ram_display,
+                SAMPLE_MEM_TOTAL_MB,
+            ),
             Some(set.battery(labels.battery(), SAMPLE_BATTERY)),
         );
         let marker = if set == current { "   <- current" } else { "" };
@@ -168,7 +193,7 @@ fn print_icon_preview(config: &config::Config, labels: &config::Labels) {
          default, `auto`, uses a Nerd Font when it finds one installed and plain\n  \
          text otherwise.\n"
     );
-    print_one_setting_hint(current);
+    print_one_setting_hint(current, config);
 }
 
 /// Explain — and print — the single edit that keeps herdr's own sidebar header
@@ -179,17 +204,37 @@ fn print_icon_preview(config: &config::Config, labels: &config::Labels) {
 /// header renders from herdr's `cpu_label` / `ram_label`, so setting only the
 /// plugin's `icons` leaves that header spelling `cpu` in words directly above a
 /// row of glyphs. Those two keys are the one place that changes both.
-fn print_one_setting_hint(current: icons::IconSet) {
+fn print_one_setting_hint(current: icons::IconSet, config: &config::Config) {
     let snippet = icons::herdr_ui_snippet(current);
     let indented: String = snippet
         .lines()
         .map(|line| format!("      {line}\n"))
         .collect();
+    // A plugin-side label silently wins over the block we are about to print, so
+    // saying nothing would send the user to edit a file that cannot take effect.
+    let overridden = [
+        ("cpu_label", config.cpu_label.is_some()),
+        ("ram_label", config.ram_label.is_some()),
+    ]
+    .iter()
+    .filter(|(_, set)| *set)
+    .map(|(key, _)| *key)
+    .collect::<Vec<_>>();
+    let note = if overridden.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "  NOTE: {} already set in the plugin's config.toml, which wins over\n  \
+             herdr's. Remove it there for the block below to reach these rows.\n\n",
+            overridden.join(" and "),
+        )
+    };
     println!(
         "  One setting for both: herdr's own sidebar system-usage header reads\n  \
          `cpu_label` / `ram_label` from ITS config, and this plugin honours the\n  \
          same keys — an explicit label replaces the tier's glyph rather than\n  \
-         stacking with it. Set them once and the header and these rows agree.\n\n  \
+         stacking with it. Set them once and the header and these rows agree.\n\n\
+         {note}  \
          For the tier above, put this in herdr's config.toml\n  \
          (alongside `icons = \"text\"` here, since the labels now do the naming):\n\n\
          {indented}"

--- a/src/render.rs
+++ b/src/render.rs
@@ -17,7 +17,7 @@ use serde_json::Number;
 
 use crate::battery::{Battery, State};
 use crate::collect;
-use crate::config::{Config, Labels, DEFAULT_RAM_LABEL};
+use crate::config::{Config, Labels, RamDisplay, DEFAULT_RAM_LABEL};
 use crate::herdr::Herdr;
 use crate::icons::IconSet;
 use crate::model::Space;
@@ -114,16 +114,19 @@ fn compact_ram(mb: f64) -> String {
 const CELL_SEPARATOR: &str = " · ";
 
 /// The narrow RAM cell — the tier's rendering of RAM as a percent of the
-/// machine's total (`ram ░8%`).
+/// machine's total (`ram ░8%`), or the compact absolute when `ram_display`
+/// says so.
 ///
 /// RAM is the one metric that is not simply a percentage. With MemTotal
 /// unreadable there is nothing to be a percentage *of*, so the cell falls back
-/// to the compact absolute (`ram 1.5G`) the sidebar has always shown there. The
-/// tier deliberately contributes nothing in that branch: a gauge glyph measures
-/// a level, and drawing one beside an absolute figure would be inventing a
+/// to the compact absolute (`ram 1.5G`) the sidebar has always shown there —
+/// and `ram_display = "gb"` picks that same form on purpose, for readers who
+/// want the figure rather than its share of this machine. The tier deliberately
+/// contributes nothing in either absolute branch: a gauge glyph measures a
+/// level, and drawing one beside an absolute figure would be inventing a
 /// reading we do not have.
-fn ram_cell(icons: IconSet, label: Option<&str>, mb: f64) -> String {
-    ram_cell_of(icons, label, mb, proc::mem_total_mb())
+fn ram_cell(icons: IconSet, label: Option<&str>, mb: f64, display: RamDisplay) -> String {
+    ram_cell_of(icons, label, mb, display, proc::mem_total_mb())
 }
 
 /// [`ram_cell`] with the machine total injected.
@@ -131,16 +134,31 @@ fn ram_cell(icons: IconSet, label: Option<&str>, mb: f64) -> String {
 /// The seam exists for the tests: the real total is read once and cached for the
 /// process, so a test host with a readable `/proc/meminfo` could never reach the
 /// fallback branch (and one without it could never reach the percent branch).
-fn ram_cell_of(icons: IconSet, label: Option<&str>, mb: f64, mem_total_mb: f64) -> String {
-    if mem_total_mb > 0.0 {
+fn ram_cell_of(
+    icons: IconSet,
+    label: Option<&str>,
+    mb: f64,
+    display: RamDisplay,
+    mem_total_mb: f64,
+) -> String {
+    if display == RamDisplay::Percent && mem_total_mb > 0.0 {
         // Same arithmetic and rounding as `proc::ram_pct`, so the Text tier
         // reproduces the pre-icons sidebar byte for byte.
         icons.ram(label, 100.0 * mb / mem_total_mb)
     } else {
-        // No total to be a percent OF, so the tier contributes nothing: a gauge
-        // glyph measures a level, and drawing one beside an absolute figure
-        // would invent a reading we do not have.
-        format!("{} {}", label.unwrap_or(DEFAULT_RAM_LABEL), compact_ram(mb))
+        absolute_ram_cell(label, mb)
+    }
+}
+
+/// The absolute RAM cell — `ram 1.5G`, with the same label rules as
+/// [`IconSet`]'s rendering: an unset label gets the default word (the tier
+/// contributes nothing beside an absolute figure), and an empty one is the
+/// deliberate "name nothing" — just the figure, no stray leading space.
+fn absolute_ram_cell(label: Option<&str>, mb: f64) -> String {
+    match label {
+        Some("") => compact_ram(mb),
+        Some(label) => format!("{label} {}", compact_ram(mb)),
+        None => format!("{DEFAULT_RAM_LABEL} {}", compact_ram(mb)),
     }
 }
 
@@ -168,10 +186,16 @@ pub fn metric_row(cpu: String, ram: String, battery: Option<String>) -> String {
 
 /// The two per-space cells both narrow rows start with, built once so the row
 /// that carries a battery and the row that cannot still agree on the first two.
-fn usage_cells(cpu: f64, ram_mb: f64, labels: &Labels, icons: IconSet) -> (String, String) {
+fn usage_cells(
+    cpu: f64,
+    ram_mb: f64,
+    labels: &Labels,
+    icons: IconSet,
+    ram_display: RamDisplay,
+) -> (String, String) {
     (
         icons.cpu(labels.cpu(), cpu),
-        ram_cell(icons, labels.ram(), ram_mb),
+        ram_cell(icons, labels.ram(), ram_mb, ram_display),
     )
 }
 
@@ -184,8 +208,14 @@ fn usage_cells(cpu: f64, ram_mb: f64, labels: &Labels, icons: IconSet) -> (Strin
 /// the terminal report on its total line, and (on a patched build) herdr's own
 /// sidebar header. Keeping the parameter off the signature is what stops a
 /// future caller from putting it back by accident.
-pub fn usage_row(cpu: f64, ram_mb: f64, labels: &Labels, icons: IconSet) -> String {
-    let (cpu_cell, ram) = usage_cells(cpu, ram_mb, labels, icons);
+pub fn usage_row(
+    cpu: f64,
+    ram_mb: f64,
+    labels: &Labels,
+    icons: IconSet,
+    ram_display: RamDisplay,
+) -> String {
+    let (cpu_cell, ram) = usage_cells(cpu, ram_mb, labels, icons, ram_display);
     metric_row(cpu_cell, ram, None)
 }
 
@@ -199,9 +229,10 @@ pub fn totals_row(
     ram_mb: f64,
     labels: &Labels,
     icons: IconSet,
+    ram_display: RamDisplay,
     battery: Option<Battery>,
 ) -> String {
-    let (cpu_cell, ram) = usage_cells(cpu, ram_mb, labels, icons);
+    let (cpu_cell, ram) = usage_cells(cpu, ram_mb, labels, icons, ram_display);
     metric_row(cpu_cell, ram, battery_cell(icons, labels, battery))
 }
 
@@ -583,12 +614,18 @@ mod tests {
     fn ram_cell_rounds_exactly_as_ram_pct_does() {
         // The pre-icons sidebar showed `proc::ram_pct`, so the Text tier has to
         // reproduce it byte for byte — these are that function's own cases.
-        assert_eq!(ram_cell_of(IconSet::Text, None, 1024.0, 16384.0), "ram 6%");
+        assert_eq!(
+            ram_cell_of(IconSet::Text, None, 1024.0, RamDisplay::Percent, 16384.0),
+            "ram 6%"
+        );
         // 100 * 250 / 10000 = 2.5 -> 3 (half away from zero).
-        assert_eq!(ram_cell_of(IconSet::Text, None, 250.0, 10000.0), "ram 3%");
+        assert_eq!(
+            ram_cell_of(IconSet::Text, None, 250.0, RamDisplay::Percent, 10000.0),
+            "ram 3%"
+        );
         // The tier decorates that same number, it does not change it.
         assert_eq!(
-            ram_cell_of(IconSet::Unicode, None, 1024.0, 16384.0),
+            ram_cell_of(IconSet::Unicode, None, 1024.0, RamDisplay::Percent, 16384.0),
             "ram ░6%",
         );
     }
@@ -598,10 +635,63 @@ mod tests {
         // No MemTotal means no scale to be a percentage of. The absolute is
         // shown with the label and *no* gauge: a gauge glyph claims a level, and
         // in this branch we have none to claim.
-        assert_eq!(ram_cell_of(IconSet::Unicode, None, 1536.0, 0.0), "ram 1.5G");
-        assert_eq!(ram_cell_of(IconSet::Text, None, 512.0, 0.0), "ram 512M");
+        assert_eq!(
+            ram_cell_of(IconSet::Unicode, None, 1536.0, RamDisplay::Percent, 0.0),
+            "ram 1.5G"
+        );
+        assert_eq!(
+            ram_cell_of(IconSet::Text, None, 512.0, RamDisplay::Percent, 0.0),
+            "ram 512M"
+        );
         // Same for a nonsensical total, which would otherwise divide by zero.
-        assert_eq!(ram_cell_of(IconSet::Emoji, None, 0.0, -1.0), "ram 0M");
+        assert_eq!(
+            ram_cell_of(IconSet::Emoji, None, 0.0, RamDisplay::Percent, -1.0),
+            "ram 0M"
+        );
+    }
+
+    #[test]
+    fn ram_display_absolute_ignores_a_readable_total() {
+        // `ram_display = "gb"` asks for the figure itself, so a perfectly
+        // readable MemTotal must not turn it back into a percent. Same absolute
+        // form as the no-total fallback, and gauge-free for the same reason.
+        let cell = |icons| ram_cell_of(icons, None, 1536.0, RamDisplay::Absolute, 16384.0);
+        assert_eq!(cell(IconSet::Text), "ram 1.5G");
+        assert_eq!(cell(IconSet::Unicode), "ram 1.5G");
+        assert_eq!(
+            ram_cell_of(IconSet::Text, None, 512.0, RamDisplay::Absolute, 16384.0),
+            "ram 512M"
+        );
+    }
+
+    #[test]
+    fn an_empty_ram_label_leaves_just_the_figure_in_the_absolute_cell() {
+        // The plugin config's "name nothing": no word and no stray leading
+        // space, whether the absolute was chosen or fallen back to.
+        assert_eq!(
+            ram_cell_of(
+                IconSet::Text,
+                Some(""),
+                1536.0,
+                RamDisplay::Absolute,
+                16384.0
+            ),
+            "1.5G"
+        );
+        assert_eq!(
+            ram_cell_of(IconSet::Text, Some(""), 1536.0, RamDisplay::Percent, 0.0),
+            "1.5G"
+        );
+    }
+
+    #[test]
+    fn a_row_with_empty_labels_and_absolute_ram_is_just_the_figures() {
+        // cpu_label = "" / ram_label = "" / ram_display = "gb" in the plugin
+        // config: bare numbers, still separated — the compact row this feature
+        // exists for.
+        let labels = Labels::new(Some(""), Some(""), None);
+        let row = usage_row(26.0, 1536.0, &labels, IconSet::Text, RamDisplay::Absolute);
+        assert_eq!(row, "26% · 1.5G");
     }
 
     #[test]
@@ -623,7 +713,13 @@ mod tests {
         // of 16384 MB is 8%) — the row builders read that total from the host.
         let row = metric_row(
             IconSet::Unicode.cpu(None, 26.0),
-            ram_cell_of(IconSet::Unicode, None, 1310.72, 16384.0),
+            ram_cell_of(
+                IconSet::Unicode,
+                None,
+                1310.72,
+                RamDisplay::Percent,
+                16384.0,
+            ),
             battery_cell(
                 IconSet::Unicode,
                 &Labels::default(),

--- a/src/render.rs
+++ b/src/render.rs
@@ -132,9 +132,13 @@ fn ram_cell(icons: IconSet, label: Option<&str>, mb: f64, display: RamDisplay) -
 
 /// [`ram_cell`] with the machine total injected.
 ///
-/// The seam exists for the tests: the real total is read once and cached for the
-/// process, so a test host with a readable `/proc/meminfo` could never reach the
-/// fallback branch (and one without it could never reach the percent branch).
+/// Two callers need that seam. The tests, because the real total is read once
+/// and cached for the process, so a test host with a readable `/proc/meminfo`
+/// could never reach the fallback branch (and one without it could never reach
+/// the percent branch). And the `--icons` preview, which draws a fixed sample
+/// reading rather than this machine's — a preview built from the host's real
+/// total would show a different row on every machine, and could not show the
+/// percent form at all on a host whose total is unreadable.
 pub(crate) fn ram_cell_of(
     icons: IconSet,
     label: Option<&str>,
@@ -668,15 +672,22 @@ mod tests {
         assert_eq!(cell(IconSet::NerdFont), "\u{efc5} 1.5G");
         assert_eq!(cell(IconSet::Emoji), "🧠1.5G");
 
-        // The row that showed the bug: both cells now speak the same language.
-        let labels = Labels::default();
-        for icons in [IconSet::NerdFont, IconSet::Emoji] {
-            let row = metric_row(icons.cpu(labels.cpu(), 26.0), cell(icons), None);
-            assert!(
-                !row.contains("ram "),
-                "{icons:?} still spells the word `ram` beside a glyph: {row}"
-            );
-        }
+        // The row that showed the bug, spelled out: both cells speak the same
+        // language. Asserted whole rather than as "no `ram` anywhere", because
+        // the row is what the user reads and a substring check would pass on a
+        // row that had gone wrong some other way.
+        let row = |icons| {
+            usage_row(
+                26.0,
+                1536.0,
+                &Labels::default(),
+                icons,
+                RamDisplay::Absolute,
+            )
+        };
+        assert_eq!(row(IconSet::NerdFont), "\u{f4bc} 26% · \u{efc5} 1.5G");
+        assert_eq!(row(IconSet::Emoji), "💻26% · 🧠1.5G");
+        assert_eq!(row(IconSet::Text), "cpu 26% · ram 1.5G");
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -17,7 +17,7 @@ use serde_json::Number;
 
 use crate::battery::{Battery, State};
 use crate::collect;
-use crate::config::{Config, Labels, RamDisplay, DEFAULT_RAM_LABEL};
+use crate::config::{Config, Labels, RamDisplay};
 use crate::herdr::Herdr;
 use crate::icons::IconSet;
 use crate::model::Space;
@@ -121,10 +121,11 @@ const CELL_SEPARATOR: &str = " · ";
 /// unreadable there is nothing to be a percentage *of*, so the cell falls back
 /// to the compact absolute (`ram 1.5G`) the sidebar has always shown there —
 /// and `ram_display = "gb"` picks that same form on purpose, for readers who
-/// want the figure rather than its share of this machine. The tier deliberately
-/// contributes nothing in either absolute branch: a gauge glyph measures a
-/// level, and drawing one beside an absolute figure would be inventing a
-/// reading we do not have.
+/// want the figure rather than its share of this machine. In both absolute
+/// branches the tier still names the metric but draws no gauge: a gauge measures
+/// a level, and drawing one beside an absolute figure would invent a reading we
+/// do not have. Naming and gauging are separate jobs — see
+/// [`IconSet::ram_absolute`].
 fn ram_cell(icons: IconSet, label: Option<&str>, mb: f64, display: RamDisplay) -> String {
     ram_cell_of(icons, label, mb, display, proc::mem_total_mb())
 }
@@ -134,7 +135,7 @@ fn ram_cell(icons: IconSet, label: Option<&str>, mb: f64, display: RamDisplay) -
 /// The seam exists for the tests: the real total is read once and cached for the
 /// process, so a test host with a readable `/proc/meminfo` could never reach the
 /// fallback branch (and one without it could never reach the percent branch).
-fn ram_cell_of(
+pub(crate) fn ram_cell_of(
     icons: IconSet,
     label: Option<&str>,
     mb: f64,
@@ -146,19 +147,9 @@ fn ram_cell_of(
         // reproduces the pre-icons sidebar byte for byte.
         icons.ram(label, 100.0 * mb / mem_total_mb)
     } else {
-        absolute_ram_cell(label, mb)
-    }
-}
-
-/// The absolute RAM cell — `ram 1.5G`, with the same label rules as
-/// [`IconSet`]'s rendering: an unset label gets the default word (the tier
-/// contributes nothing beside an absolute figure), and an empty one is the
-/// deliberate "name nothing" — just the figure, no stray leading space.
-fn absolute_ram_cell(label: Option<&str>, mb: f64) -> String {
-    match label {
-        Some("") => compact_ram(mb),
-        Some(label) => format!("{label} {}", compact_ram(mb)),
-        None => format!("{DEFAULT_RAM_LABEL} {}", compact_ram(mb)),
+        // The tier still names the metric; what it withholds is the gauge. See
+        // [`IconSet::ram_absolute`] for why those are two different jobs.
+        icons.ram_absolute(label, &compact_ram(mb))
     }
 }
 
@@ -633,8 +624,8 @@ mod tests {
     #[test]
     fn ram_cell_falls_back_to_the_compact_absolute_without_a_total() {
         // No MemTotal means no scale to be a percentage of. The absolute is
-        // shown with the label and *no* gauge: a gauge glyph claims a level, and
-        // in this branch we have none to claim.
+        // shown with *no* gauge: a gauge claims a level, and in this branch we
+        // have none to claim.
         assert_eq!(
             ram_cell_of(IconSet::Unicode, None, 1536.0, RamDisplay::Percent, 0.0),
             "ram 1.5G"
@@ -644,17 +635,17 @@ mod tests {
             "ram 512M"
         );
         // Same for a nonsensical total, which would otherwise divide by zero.
+        // The glyph here is the metric's NAME, not a gauge, so it stays.
         assert_eq!(
             ram_cell_of(IconSet::Emoji, None, 0.0, RamDisplay::Percent, -1.0),
-            "ram 0M"
+            "🧠0M"
         );
     }
 
     #[test]
     fn ram_display_absolute_ignores_a_readable_total() {
         // `ram_display = "gb"` asks for the figure itself, so a perfectly
-        // readable MemTotal must not turn it back into a percent. Same absolute
-        // form as the no-total fallback, and gauge-free for the same reason.
+        // readable MemTotal must not turn it back into a percent.
         let cell = |icons| ram_cell_of(icons, None, 1536.0, RamDisplay::Absolute, 16384.0);
         assert_eq!(cell(IconSet::Text), "ram 1.5G");
         assert_eq!(cell(IconSet::Unicode), "ram 1.5G");
@@ -662,6 +653,30 @@ mod tests {
             ram_cell_of(IconSet::Text, None, 512.0, RamDisplay::Absolute, 16384.0),
             "ram 512M"
         );
+    }
+
+    #[test]
+    fn the_absolute_cell_keeps_each_tier_naming_but_drops_the_gauge() {
+        // The bug this pins: an absolute cell that named itself `ram` in EVERY
+        // tier put the word `ram` next to a glyph `cpu` cell in the same row —
+        // precisely the drift the tiers exist to prevent. Naming and gauging are
+        // separate jobs, and only the gauge needs a level to measure.
+        let cell = |icons| ram_cell_of(icons, None, 1536.0, RamDisplay::Absolute, 16384.0);
+        assert_eq!(cell(IconSet::Text), "ram 1.5G");
+        // Unicode names with the word and drops ONLY its gauge glyph.
+        assert_eq!(cell(IconSet::Unicode), "ram 1.5G");
+        assert_eq!(cell(IconSet::NerdFont), "\u{efc5} 1.5G");
+        assert_eq!(cell(IconSet::Emoji), "🧠1.5G");
+
+        // The row that showed the bug: both cells now speak the same language.
+        let labels = Labels::default();
+        for icons in [IconSet::NerdFont, IconSet::Emoji] {
+            let row = metric_row(icons.cpu(labels.cpu(), 26.0), cell(icons), None);
+            assert!(
+                !row.contains("ram "),
+                "{icons:?} still spells the word `ram` beside a glyph: {row}"
+            );
+        }
     }
 
     #[test]
@@ -682,6 +697,20 @@ mod tests {
             ram_cell_of(IconSet::Text, Some(""), 1536.0, RamDisplay::Percent, 0.0),
             "1.5G"
         );
+        // "Name nothing" beats the tier's naming in every tier, glyph ones
+        // included — otherwise the emoji would sneak back in as the name.
+        for icons in [
+            IconSet::Text,
+            IconSet::Unicode,
+            IconSet::NerdFont,
+            IconSet::Emoji,
+        ] {
+            assert_eq!(
+                ram_cell_of(icons, Some(""), 1536.0, RamDisplay::Absolute, 16384.0),
+                "1.5G",
+                "{icons:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -113,6 +113,47 @@ fn compact_ram(mb: f64) -> String {
 /// Separator between the cells of a narrow metric row.
 const CELL_SEPARATOR: &str = " · ";
 
+/// Everything that decides how a narrow row looks: the naming, the glyph
+/// vocabulary, and the form the RAM figure takes.
+///
+/// Grouped for the same reason [`crate::daemon`]'s `Settings` is — these are one
+/// decision, not three, and a caller that refreshed the labels while keeping a
+/// stale tier would render a mixture. Passing them as parallel arguments also
+/// meant every new presentation knob had to be threaded through five signatures
+/// and every test call site; `ram_display` was the one that made that plain.
+///
+/// Narrow rows only, which is why it carries `ram_display`: the wide terminal
+/// report always prints the absolute AND the percent, so it has nothing to
+/// switch, and handing it a setting it ignores would invite a future caller to
+/// believe it did something.
+#[derive(Debug, Clone, Copy)]
+pub struct RowStyle<'a> {
+    labels: &'a Labels,
+    icons: IconSet,
+    ram_display: RamDisplay,
+}
+
+impl<'a> RowStyle<'a> {
+    /// Build a style from its parts.
+    ///
+    /// `icons` is taken rather than re-derived because resolving the tier is a
+    /// once-per-refresh decision for the whole machine — see
+    /// [`crate::config::Config::icon_set`].
+    pub fn new(labels: &'a Labels, icons: IconSet, ram_display: RamDisplay) -> Self {
+        Self {
+            labels,
+            icons,
+            ram_display,
+        }
+    }
+
+    /// The style this plugin's own config asks for, with the tier already
+    /// resolved by the caller.
+    pub fn from_config(labels: &'a Labels, icons: IconSet, config: &Config) -> Self {
+        Self::new(labels, icons, config.ram_display)
+    }
+}
+
 /// The narrow RAM cell — the tier's rendering of RAM as a percent of the
 /// machine's total (`ram ░8%`), or the compact absolute when `ram_display`
 /// says so.
@@ -181,16 +222,10 @@ pub fn metric_row(cpu: String, ram: String, battery: Option<String>) -> String {
 
 /// The two per-space cells both narrow rows start with, built once so the row
 /// that carries a battery and the row that cannot still agree on the first two.
-fn usage_cells(
-    cpu: f64,
-    ram_mb: f64,
-    labels: &Labels,
-    icons: IconSet,
-    ram_display: RamDisplay,
-) -> (String, String) {
+fn usage_cells(cpu: f64, ram_mb: f64, style: RowStyle) -> (String, String) {
     (
-        icons.cpu(labels.cpu(), cpu),
-        ram_cell(icons, labels.ram(), ram_mb, ram_display),
+        style.icons.cpu(style.labels.cpu(), cpu),
+        ram_cell(style.icons, style.labels.ram(), ram_mb, style.ram_display),
     )
 }
 
@@ -203,14 +238,8 @@ fn usage_cells(
 /// the terminal report on its total line, and (on a patched build) herdr's own
 /// sidebar header. Keeping the parameter off the signature is what stops a
 /// future caller from putting it back by accident.
-pub fn usage_row(
-    cpu: f64,
-    ram_mb: f64,
-    labels: &Labels,
-    icons: IconSet,
-    ram_display: RamDisplay,
-) -> String {
-    let (cpu_cell, ram) = usage_cells(cpu, ram_mb, labels, icons, ram_display);
+pub fn usage_row(cpu: f64, ram_mb: f64, style: RowStyle) -> String {
+    let (cpu_cell, ram) = usage_cells(cpu, ram_mb, style);
     metric_row(cpu_cell, ram, None)
 }
 
@@ -219,16 +248,13 @@ pub fn usage_row(
 ///
 /// `battery` is the reading taken once per refresh cycle by
 /// [`Config::battery_reading`] and passed down, never re-read here.
-pub fn totals_row(
-    cpu: f64,
-    ram_mb: f64,
-    labels: &Labels,
-    icons: IconSet,
-    ram_display: RamDisplay,
-    battery: Option<Battery>,
-) -> String {
-    let (cpu_cell, ram) = usage_cells(cpu, ram_mb, labels, icons, ram_display);
-    metric_row(cpu_cell, ram, battery_cell(icons, labels, battery))
+pub fn totals_row(cpu: f64, ram_mb: f64, style: RowStyle, battery: Option<Battery>) -> String {
+    let (cpu_cell, ram) = usage_cells(cpu, ram_mb, style);
+    metric_row(
+        cpu_cell,
+        ram,
+        battery_cell(style.icons, style.labels, battery),
+    )
 }
 
 // ---- human render -----------------------------------------------------------
@@ -676,13 +702,12 @@ mod tests {
         // language. Asserted whole rather than as "no `ram` anywhere", because
         // the row is what the user reads and a substring check would pass on a
         // row that had gone wrong some other way.
+        let labels = Labels::default();
         let row = |icons| {
             usage_row(
                 26.0,
                 1536.0,
-                &Labels::default(),
-                icons,
-                RamDisplay::Absolute,
+                RowStyle::new(&labels, icons, RamDisplay::Absolute),
             )
         };
         assert_eq!(row(IconSet::NerdFont), "\u{f4bc} 26% · \u{efc5} 1.5G");
@@ -730,8 +755,36 @@ mod tests {
         // config: bare numbers, still separated — the compact row this feature
         // exists for.
         let labels = Labels::new(Some(""), Some(""), None);
-        let row = usage_row(26.0, 1536.0, &labels, IconSet::Text, RamDisplay::Absolute);
+        let row = usage_row(
+            26.0,
+            1536.0,
+            RowStyle::new(&labels, IconSet::Text, RamDisplay::Absolute),
+        );
         assert_eq!(row, "26% · 1.5G");
+    }
+
+    #[test]
+    fn a_style_built_from_config_carries_that_configs_ram_form() {
+        // The wiring, not the rendering. Every other test hands the row builders
+        // a `RamDisplay` literal, so a `from_config` that read the wrong field —
+        // or quietly hardcoded the default — would still pass all of them and
+        // leave `ram_display = "gb"` doing nothing on a real machine.
+        //
+        // Asserted on the fields rather than on rendered output because the
+        // percent branch needs a readable MemTotal, and a host without one would
+        // render both forms identically and pass either way.
+        let labels = Labels::default();
+        for ram_display in [RamDisplay::Percent, RamDisplay::Absolute] {
+            let config = Config {
+                ram_display,
+                ..Config::default()
+            };
+            let style = RowStyle::from_config(&labels, IconSet::NerdFont, &config);
+            assert_eq!(style.ram_display, ram_display);
+            // The tier is the caller's, resolved once per refresh, not re-derived
+            // from the config here.
+            assert_eq!(style.icons, IconSet::NerdFont);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

Two additions to the plugin's own `config.toml`, both for the narrow cells (the sidebar rows and the window title):

- `ram_display = "gb"` (or `"absolute"`) keeps the RAM cell in the compact absolute form (`513M` / `1.5G`) even when MemTotal is readable. The default stays `percent`, and the chosen-absolute branch renders exactly like the existing no-total fallback — gauge-free, for the reason `ram_cell` already documents.
- `cpu_label` / `ram_label` as per-key overrides of herdr's `[ui]` values. An unset key keeps falling back to herdr's config, so a patched build that shares those keys with its system-usage header keeps its single source of truth by simply not setting them here.

## Why

On a stock build herdr draws no system-usage header, so `cpu_label` / `ram_label` are not keys it knows — they work from herdr's `[ui]`, but `herdr config check` and every `reload-config` flag them as unknown. That is the same noise that moved `battery_label` into the plugin file; this gives the other two labels the same escape hatch without giving up the shared-key story for patched builds.

The RAM percent answers "how much of this machine", but sometimes the figure itself is the number you want: on a box with memory to spare, a space using 1.5G reads as `2%`, which says almost nothing.

One deliberate semantic to call out: an empty plugin-side label is honoured as the "name nothing" the renderer already documents (bare number — no word, no glyph, no stray leading space) rather than reading as unset the way herdr-side blanks do. The herdr-side rule exists because herdr ships those keys as blank commented templates, so a blank there is usually an accident; nothing ships these plugin keys at all, so a blank here can only be intentional. `battery_label` is left exactly as it was. With both keys empty and `ram_display = "gb"`, a row is just `26% · 1.5G`.

## Tests

- `config.rs`: `ram_display` parsing (default, `gb` / `absolute` / `percent`, unknown values ignored), per-key override precedence, and the empty-label-is-not-unset case, including the wide report's word fallback.
- `render.rs`: the chosen-absolute cell ignoring a readable total, the empty-label absolute cell in both branches, and the bare-figures row.
- Existing tests only gained the threaded parameter. `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --all` (198 passed) are green locally.

README gains the key in the config sample and a short section beside the existing label documentation.
