### PR TITLE
fix: the overlay updater only runs for one herdr session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "space-usage"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "libc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "space-usage"
-version = "1.11.0"
+version = "1.11.1"
 edition = "2021"
 description = "CPU and RAM usage per herdr space, grouped under the branch name."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ herdr plugin action invoke status-disable --plugin ez-corp.space-usage
 ```
 
 `status-enable` brings it back — the updater and the config row both;
-`status-toggle` flips whichever way it is.
+`status-toggle` flips whichever way it is. With more than one herdr session
+running, all three reach every session — [see below](#more-than-one-herdr-session).
 
 Other entrypoints:
 
@@ -143,7 +144,9 @@ Status **text** carries a TTL and self-clears if the updater dies. In
 agents-panel mode the `usage` pseudo-agent row itself has no TTL (herdr's
 `pane.report_agent` takes none), so a hard-killed updater leaves an empty row
 behind until the next `status-enable`/`status-disable`. Disabling clears
-everything immediately either way.
+everything immediately either way, in every session — it clears each one over
+that session's own socket, which is the only connection its rows can be taken
+back through.
 
 The updater **survives herdr restarts**, and comes up on its own after an
 install. herdr runs the manifest's `[[startup]]` hook (`--restore`) on every
@@ -170,7 +173,8 @@ What is per session and what is not follows from where herdr keeps things:
 | | Scope | Why |
 |---|---|---|
 | The updater and its pid file | Per session | It can only push to the socket it is connected to. |
-| `status-enable` / `status-disable` | Every session | herdr gives the plugin ONE state dir per user, and the `$usage` row lives in the ONE config every session renders — so the decision cannot be per session. `status-disable` stands down every session's updater. |
+| `status-disable` | Every session, at once | herdr gives the plugin ONE state dir per user, and the `$usage` row lives in the ONE config every session renders — so the decision cannot be per session. It stands down every session's updater and clears every session's rows. |
+| `status-enable` | Every session, this one first | Same shared decision, but it can only start a daemon where it runs: this session lights up immediately, the others at their next space switch, when their own restore hook fires. |
 | `status-toggle` | Reads this session, off reaches all | The sidebar in front of you decides which way it flips, so a session with no updater turns one on even while another session has one. Toggling **off** still turns every session off — see below. |
 | Plugin config | Every session | One config dir per user, re-read every refresh. |
 

--- a/README.md
+++ b/README.md
@@ -171,8 +171,20 @@ What is per session and what is not follows from where herdr keeps things:
 |---|---|---|
 | The updater and its pid file | Per session | It can only push to the socket it is connected to. |
 | `status-enable` / `status-disable` | Every session | herdr gives the plugin ONE state dir per user, and the `$usage` row lives in the ONE config every session renders — so the decision cannot be per session. `status-disable` stands down every session's updater. |
-| `status-toggle` | Reads this session | The sidebar in front of you is the one it flips: a session with no updater turns one on, even while another session has one. |
+| `status-toggle` | Reads this session, off reaches all | The sidebar in front of you decides which way it flips, so a session with no updater turns one on even while another session has one. Toggling **off** still turns every session off — see below. |
 | Plugin config | Every session | One config dir per user, re-read every refresh. |
+
+**There is no session-local "off".** One marker per user records the decision,
+and the restore hook fires on every space switch — so a session trying to keep
+its own updater down would have it back on the next switch. Turning the overlay
+off is therefore one decision for every session, whichever session you run it
+from. Turning it on starts that session's updater; the rest follow on their next
+space switch.
+
+Nothing to configure either way. herdr keeps plugins global to the user on
+purpose — one registry, one state dir, one config dir — which is also why a
+second session runs this plugin's startup hook at all
+([herdr#1174](https://github.com/herdrdev/herdr/issues/1174), v0.7.5).
 
 > **Upgrading from < 1.8.0?** Two defaults changed, both toward "works without
 > being told": the updater now runs unless you have disabled it, and `mode`

--- a/README.md
+++ b/README.md
@@ -157,6 +157,23 @@ fresh install → run), enabled, and disabled. Only the last keeps it down, so a
 deliberate `status-disable` stays disabled across restarts while a new install
 starts itself. Requires herdr ≥ 0.7.5; verified against 0.7.5 and 0.8.0.
 
+### More than one herdr session
+
+Every session gets its own updater. Each one runs its own server on its own
+socket, and an updater pushes over the one socket it connected to, so a session
+without an updater of its own would show a `$usage` row with nothing in it
+(#5, fixed in 1.11.1 — before it, the first session to start claimed the single
+global pid file and every other session stood down).
+
+What is per session and what is not follows from where herdr keeps things:
+
+| | Scope | Why |
+|---|---|---|
+| The updater and its pid file | Per session | It can only push to the socket it is connected to. |
+| `status-enable` / `status-disable` | Every session | herdr gives the plugin ONE state dir per user, and the `$usage` row lives in the ONE config every session renders — so the decision cannot be per session. `status-disable` stands down every session's updater. |
+| `status-toggle` | Reads this session | The sidebar in front of you is the one it flips: a session with no updater turns one on, even while another session has one. |
+| Plugin config | Every session | One config dir per user, re-read every refresh. |
+
 > **Upgrading from < 1.8.0?** Two defaults changed, both toward "works without
 > being told": the updater now runs unless you have disabled it, and `mode`
 > defaults to `sidebar` rather than `agents-panel`. If you had deliberately left

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -51,12 +51,20 @@ platforms = ["linux", "macos", "windows"]
 # a herdr that is already running sits inert until the next restart — most of
 # what "I installed it and nothing happened" used to mean.
 #
-# That covers a FIRST install. A reinstall needs one more thing: the previous
-# version's daemon is still running, and `--restore` leaves any live daemon
-# alone, so the replaced binary would keep serving the old build until the next
-# herdr restart. The daemon therefore watches its own executable and hands over
-# to a replacement when it is rebuilt or reinstalled underneath it (see
-# `run_daemon`), since nothing outside it is in a position to notice.
+# That covers a FIRST install. A reinstall used to need one more thing: the
+# previous version's daemon is still running, `--restore` leaves any live daemon
+# alone, and it held the ONE claim there was — so the new build did not take
+# effect at all until the next herdr restart. Per-session claims settle that:
+# the new build claims its own session's pid file and starts serving straight
+# away (see `config::pid_file`).
+#
+# The daemon also watches its own executable and hands over when it is REBUILT
+# underneath it, which is the dev-link workflow. Measured against herdr 0.8.0,
+# that does not extend to `herdr plugin install`: it moves the whole checkout
+# aside and deletes it, so the running daemon's executable is unlinked rather
+# than rewritten, and it cannot stat itself to notice (see `run_daemon`). After
+# a reinstall the old process therefore lingers, redundant, until its herdr
+# server goes away.
 #
 # `workspace.focused` is the earliest event a real user reliably produces, and
 # `--restore` is idempotent and exits in microseconds once the daemon is live

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -14,7 +14,7 @@
 
 id = "ez-corp.space-usage"
 name = "PC RAM & CPU Usage Overlay"
-version = "1.11.0"
+version = "1.11.1"
 # Oldest herdr with every API this plugin calls: `session.snapshot`, the `tokens`
 # metadata API on `pane.report_metadata` / `workspace.report_metadata`, and
 # `pane.process_info` — all 0.7.5. Diffing the two bundled API schemas

--- a/src/battery.rs
+++ b/src/battery.rs
@@ -456,7 +456,9 @@ mod power_status {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
+
+    use crate::testutil::scratch;
 
     // ---- shared: the percentage gate ----------------------------------------
 
@@ -1064,20 +1066,6 @@ mod tests {
             state,
             charge,
         }
-    }
-
-    /// Unique scratch dir under the system tmpdir, keyed by test name + pid +
-    /// thread id so parallel test threads never collide (the same shape as the
-    /// daemon tests' helper).
-    fn scratch(name: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "space-usage-battery-test-{name}-{}-{:?}",
-            std::process::id(),
-            std::thread::current().id(),
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("scratch dir");
-        dir
     }
 
     /// Write a fixture power-supply directory: `<root>/<name>/<attr>` holding

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -158,10 +158,10 @@ fn workspaces_with_roles(
 /// mid-scan errors there and simply contributes no root.
 pub fn collect_spaces(client: &mut Herdr) -> crate::Result<Vec<Space>> {
     let snapshot = client.session_snapshot()?;
-    let by_workspace = workspaces_with_roles(&snapshot);
+    let workspaces = workspaces_with_roles(&snapshot);
 
-    let mut spaces = Vec::with_capacity(by_workspace.len());
-    for (ws, panes, roles) in by_workspace {
+    let mut spaces = Vec::with_capacity(workspaces.len());
+    for (ws, panes, roles) in workspaces {
         // Best-effort shell PIDs; a pane that just closed errors and is skipped.
         let mut roots: Vec<u32> = Vec::with_capacity(panes.len());
         for pane in &panes {

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -24,15 +24,15 @@ pub const PSEUDO_AGENT: &str = "usage";
 /// Split out of [`collect_spaces`] so the classification rules are unit-testable
 /// without a live herdr.
 #[derive(Debug, Default, PartialEq, Eq)]
-struct PaneRoles {
+pub struct PaneRoles {
     /// cwd of the first pane that reports one — the branch lookup path.
-    cwd: Option<String>,
+    pub cwd: Option<String>,
     /// panes with a real agent.
-    agent_panes: Vec<String>,
+    pub agent_panes: Vec<String>,
     /// plain shell panes.
-    spare_panes: Vec<String>,
+    pub spare_panes: Vec<String>,
     /// panes already carrying our "usage" pseudo-agent.
-    pseudo_panes: Vec<String>,
+    pub pseudo_panes: Vec<String>,
 }
 
 /// Classify one workspace's panes, in the order herdr reported them.
@@ -99,6 +99,32 @@ fn panes_by_workspace(panes: &[PaneInfo]) -> HashMap<&str, Vec<&PaneInfo>> {
             .push(pane);
     }
     by_workspace
+}
+
+/// Every pane and workspace this plugin could have pushed a status onto, from
+/// ONE snapshot call: `(workspace id, its panes by role)`.
+///
+/// What a sweep needs, and deliberately not [`collect_spaces`], which answers a
+/// bigger question at a much higher price — a `pane.process_info` round trip per
+/// pane and a `git` fork per workspace, for numbers a sweep throws away. That
+/// price is paid in the one place it hurts most: `--disable` reaches into
+/// sessions nothing has shown to be healthy, and against one that has stopped
+/// answering, every extra round trip is another full socket timeout the user
+/// waits through — or, on Windows, where a pipe opened as a `File` has no
+/// timeout to reach, another wait with no end.
+pub fn sweep_targets(client: &mut Herdr) -> crate::Result<Vec<(String, PaneRoles)>> {
+    let snapshot = client.session_snapshot()?;
+    let by_workspace = panes_by_workspace(&snapshot.panes);
+    Ok(snapshot
+        .workspaces
+        .iter()
+        .map(|ws| {
+            let panes: &[&PaneInfo] = by_workspace
+                .get(ws.workspace_id.as_str())
+                .map_or(&[], Vec::as_slice);
+            (ws.workspace_id.clone(), classify_panes(panes))
+        })
+        .collect())
 }
 
 /// Enumerate spaces and the root shell PID of each of their panes, classifying

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -11,7 +11,7 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use crate::herdr::Herdr;
-use crate::model::{PaneInfo, Space};
+use crate::model::{PaneInfo, SessionSnapshot, Space, WorkspaceInfo};
 use crate::proc;
 
 /// Pseudo-agent label used to mark our agents-panel entries (agents-panel mode)
@@ -114,17 +114,38 @@ fn panes_by_workspace(panes: &[PaneInfo]) -> HashMap<&str, Vec<&PaneInfo>> {
 /// timeout to reach, another wait with no end.
 pub fn sweep_targets(client: &mut Herdr) -> crate::Result<Vec<(String, PaneRoles)>> {
     let snapshot = client.session_snapshot()?;
+    Ok(workspaces_with_roles(&snapshot)
+        .into_iter()
+        .map(|(ws, _, roles)| (ws.workspace_id.clone(), roles))
+        .collect())
+}
+
+/// Every workspace in `snapshot`, with its panes and how those panes classify,
+/// in the order herdr reported them.
+///
+/// The one walk both readers share. They want different things from it —
+/// [`sweep_targets`] the pane ids alone, [`collect_spaces`] a sample per pane on
+/// top — but they must agree on *which* workspaces exist and which pane belongs
+/// to which role, because a pane the sweep does not know about is a status
+/// nothing takes back, and in agents-panel mode that row carries no TTL to
+/// clear it. Two walks that could drift is the way to get that wrong quietly,
+/// so there is one.
+fn workspaces_with_roles(
+    snapshot: &SessionSnapshot,
+) -> Vec<(&WorkspaceInfo, Vec<&PaneInfo>, PaneRoles)> {
     let by_workspace = panes_by_workspace(&snapshot.panes);
-    Ok(snapshot
+    snapshot
         .workspaces
         .iter()
         .map(|ws| {
-            let panes: &[&PaneInfo] = by_workspace
+            let panes = by_workspace
                 .get(ws.workspace_id.as_str())
-                .map_or(&[], Vec::as_slice);
-            (ws.workspace_id.clone(), classify_panes(panes))
+                .cloned()
+                .unwrap_or_default();
+            let roles = classify_panes(&panes);
+            (ws, panes, roles)
         })
-        .collect())
+        .collect()
 }
 
 /// Enumerate spaces and the root shell PID of each of their panes, classifying
@@ -137,18 +158,13 @@ pub fn sweep_targets(client: &mut Herdr) -> crate::Result<Vec<(String, PaneRoles
 /// mid-scan errors there and simply contributes no root.
 pub fn collect_spaces(client: &mut Herdr) -> crate::Result<Vec<Space>> {
     let snapshot = client.session_snapshot()?;
-    let by_workspace = panes_by_workspace(&snapshot.panes);
+    let by_workspace = workspaces_with_roles(&snapshot);
 
-    let mut spaces = Vec::with_capacity(snapshot.workspaces.len());
-    for ws in &snapshot.workspaces {
-        let panes: &[&PaneInfo] = by_workspace
-            .get(ws.workspace_id.as_str())
-            .map_or(&[], Vec::as_slice);
-        let roles = classify_panes(panes);
-
+    let mut spaces = Vec::with_capacity(by_workspace.len());
+    for (ws, panes, roles) in by_workspace {
         // Best-effort shell PIDs; a pane that just closed errors and is skipped.
-        let mut roots = Vec::with_capacity(panes.len());
-        for pane in panes {
+        let mut roots: Vec<u32> = Vec::with_capacity(panes.len());
+        for pane in &panes {
             if let Ok(info) = client.process_info(&pane.pane_id) {
                 if let Some(pid) = info.shell_pid.filter(|&p| p != 0) {
                     roots.push(pid);
@@ -363,7 +379,7 @@ pub fn snapshot(client: &mut Herdr, window_ms: u64) -> crate::Result<Vec<Space>>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{PaneInfo, Space};
+    use crate::model::{PaneInfo, Space, WorkspaceInfo};
 
     /// Build a [`PaneInfo`] as `session.snapshot` reports one.
     fn pane(pane_id: &str, workspace_id: &str, cwd: Option<&str>, agent: Option<&str>) -> PaneInfo {
@@ -376,6 +392,15 @@ mod tests {
         }
     }
 
+    /// Terse [`WorkspaceInfo`] builder for the walk test.
+    fn workspace(workspace_id: &str, label: &str) -> WorkspaceInfo {
+        WorkspaceInfo {
+            workspace_id: workspace_id.to_string(),
+            label: label.to_string(),
+            focused: false,
+        }
+    }
+
     /// A [`PaneInfo`] carrying metadata tokens with the given keys.
     fn pane_with_tokens(pane_id: &str, keys: &[&str]) -> PaneInfo {
         let mut p = pane(pane_id, "w1", None, None);
@@ -385,6 +410,51 @@ mod tests {
                 .collect(),
         );
         p
+    }
+
+    // ---- the walk both readers share -----------------------------------------
+
+    #[test]
+    fn every_workspace_comes_back_with_its_own_panes_and_their_roles() {
+        // `collect_spaces` samples each space and `sweep_targets` clears it, and
+        // the two must agree on which workspaces exist and which pane plays
+        // which part — a pane the sweep never hears about is a status nothing
+        // takes back, and in agents-panel mode that row has no TTL to fall back
+        // on. They agree by construction, sharing this walk; what is left to
+        // pin is the walk itself. Neither caller can be tested directly, both
+        // needing a live herdr on the other end of a socket.
+        let snapshot = SessionSnapshot {
+            workspaces: vec![
+                workspace("w1", "first"),
+                workspace("w2", "second"),
+                workspace("w3", "empty"),
+            ],
+            panes: vec![
+                pane("w2:p1", "w2", None, None),
+                pane("w1:p1", "w1", Some("/repo"), Some("claude")),
+                pane("w1:p2", "w1", None, None),
+                pane("w1:p3", "w1", None, Some(PSEUDO_AGENT)),
+            ],
+        };
+
+        let walked = workspaces_with_roles(&snapshot);
+        let ids: Vec<&str> = walked.iter().map(|(ws, ..)| &*ws.workspace_id).collect();
+        assert_eq!(ids, ["w1", "w2", "w3"], "every workspace, in herdr's order");
+
+        let (_, panes, roles) = &walked[0];
+        let held: Vec<&str> = panes.iter().map(|p| &*p.pane_id).collect();
+        assert_eq!(held, ["w1:p1", "w1:p2", "w1:p3"], "its own panes only");
+        assert_eq!(roles.agent_panes, ["w1:p1"]);
+        assert_eq!(roles.spare_panes, ["w1:p2"]);
+        assert_eq!(roles.pseudo_panes, ["w1:p3"]);
+        assert_eq!(roles.cwd.as_deref(), Some("/repo"));
+
+        // A workspace with no panes still comes back: it may carry a workspace
+        // token of ours, and a sweep that skipped it would strand one.
+        let (ws, panes, roles) = &walked[2];
+        assert_eq!(ws.workspace_id, "w3");
+        assert!(panes.is_empty());
+        assert!(roles.agent_panes.is_empty() && roles.spare_panes.is_empty());
     }
 
     // ---- pane bucketing + classification ------------------------------------

--- a/src/config.rs
+++ b/src/config.rs
@@ -393,9 +393,19 @@ pub fn config_dir() -> PathBuf {
 /// therefore made the updater one-per-*machine* rather than one-per-session —
 /// the second session's `--restore` found the first session's live daemon,
 /// stood down, and left its sidebar blank, since a daemon can only push to the
-/// one socket it is connected to. See [`crate::herdr::session_key`].
+/// one socket it is connected to. See [`crate::herdr::session_key_of`].
 pub fn pid_file() -> PathBuf {
-    state_dir().join(pid_file_name(&crate::herdr::session_key()))
+    pid_file_in(&state_dir(), &crate::herdr::socket_path_string())
+}
+
+/// [`pid_file`] from an explicit state dir and socket path.
+///
+/// The seam is where it is so a test can hold the whole chain — socket path to
+/// key to file name — rather than restating it. A test that computed the key
+/// the same way this does would pass just as happily against a key that had
+/// stopped depending on the socket at all, which is the bug coming back.
+fn pid_file_in(state_dir: &std::path::Path, socket_path: &str) -> PathBuf {
+    state_dir.join(pid_file_name(&crate::herdr::session_key_of(socket_path)))
 }
 
 /// The pid file name one session key claims.
@@ -1245,20 +1255,51 @@ mod tests {
     }
 
     #[test]
-    fn this_sessions_claim_carries_this_sessions_key() {
-        // The wiring, not just the naming. Every other test here builds a name
-        // from a key by hand, so a `pid_file` that went back to a fixed name —
-        // and so to one updater for the whole machine — would sail past all of
-        // them. Host-independent: whatever socket this run resolves, the file
-        // has to be named after it and not after the pre-1.11.1 scheme.
-        let name = pid_file()
-            .file_name()
-            .expect("a pid file has a name")
-            .to_string_lossy()
-            .into_owned();
-        assert_eq!(name, pid_file_name(&crate::herdr::session_key()));
-        assert!(name.contains(&crate::herdr::session_key()), "got: {name}");
-        assert_ne!(name, LEGACY_PID_FILE);
+    fn two_sessions_get_two_pid_files_and_one_session_gets_one() {
+        // The property, not a restatement of the arithmetic. Every other test
+        // here starts from a key, so they all pass just as happily against a
+        // `pid_file` that had stopped reading the socket — a fixed name, or a
+        // constant key — which is one updater for the whole machine, i.e. the
+        // bug. This one starts from the socket, which is the only input that
+        // tells two sessions apart.
+        let dir = std::path::Path::new("/state");
+        let default = pid_file_in(dir, "/home/u/.config/herdr/herdr.sock");
+        let named = pid_file_in(dir, "/home/u/.config/herdr/sessions/second/herdr.sock");
+
+        assert_ne!(default, named, "two sessions cannot share one claim");
+        assert_eq!(
+            default,
+            pid_file_in(dir, "/home/u/.config/herdr/herdr.sock"),
+            "one session has to find the claim it left last time",
+        );
+        assert_eq!(default.parent(), Some(dir), "it lives in the state dir");
+        assert_ne!(
+            default.file_name().unwrap(),
+            std::ffi::OsStr::new(LEGACY_PID_FILE),
+            "and not under the name every session used to share",
+        );
+    }
+
+    #[test]
+    fn the_pid_file_this_session_uses_is_the_one_its_socket_names() {
+        // The other half, and not redundant with it: the test above proves the
+        // naming depends on the socket, this one proves `pid_file` still asks.
+        // Each catches a mutation the other passes — a key that ignores the
+        // socket path there, a `pid_file` that goes back to a fixed name here.
+        // Both end at one updater for the whole machine, which is the bug.
+        let mine = pid_file();
+        assert_eq!(
+            mine,
+            pid_file_in(&state_dir(), &crate::herdr::socket_path_string()),
+        );
+        assert_ne!(
+            mine,
+            pid_file_in(&state_dir(), "/not/the/socket/this/run/resolved.sock"),
+        );
+        assert_ne!(
+            mine.file_name().unwrap(),
+            std::ffi::OsStr::new(LEGACY_PID_FILE),
+        );
     }
 
     #[test]
@@ -1271,9 +1312,11 @@ mod tests {
             pid_file_name("aaaaaaaa"),
             pid_file_name("bbbbbbbb"),
             LEGACY_PID_FILE.to_string(),
-            // An empty key is still this scheme's shape — a socket path that
-            // could not be resolved. A file we cannot explain is safer swept
-            // than left holding a claim nothing ever releases.
+            // Nothing this plugin writes produces an empty key — an unresolved
+            // socket path hashes like any other string. It is here because a
+            // file of this shape that we cannot explain, hand-written or
+            // truncated, is safer swept than left holding a claim nothing ever
+            // releases.
             "updater-.pid".to_string(),
         ] {
             std::fs::write(dir.join(name), "1\n").expect("fixture pid file");

--- a/src/config.rs
+++ b/src/config.rs
@@ -384,9 +384,68 @@ pub fn config_dir() -> PathBuf {
         .unwrap_or_else(|| std::env::temp_dir().join(format!("{}-config", plugin_id())))
 }
 
-/// Updater single-instance pid file (`<state_dir>/updater.pid`).
+/// Updater single-instance pid file for the herdr session this process talks to
+/// (`<state_dir>/updater-<session>.pid`).
+///
+/// Keyed by session because the state dir is not: herdr gives each user one
+/// `HERDR_PLUGIN_STATE_DIR` per plugin and every session shares it, while each
+/// session runs its own server on its own socket. A single global pid file
+/// therefore made the updater one-per-*machine* rather than one-per-session —
+/// the second session's `--restore` found the first session's live daemon,
+/// stood down, and left its sidebar blank, since a daemon can only push to the
+/// one socket it is connected to. See [`crate::herdr::session_key`].
 pub fn pid_file() -> PathBuf {
-    state_dir().join("updater.pid")
+    state_dir().join(pid_file_name(&crate::herdr::session_key()))
+}
+
+/// The pid file name one session key claims.
+pub(crate) fn pid_file_name(session_key: &str) -> String {
+    format!("updater-{session_key}.pid")
+}
+
+/// Pid file written by versions before 1.11.1, when the updater was
+/// one-per-machine.
+///
+/// Still swept by `--disable` so an upgrade cannot strand the daemon that was
+/// running at the time. Deliberately NOT honoured as a single-instance claim:
+/// it says nothing about *which* session's daemon holds it, and treating it as
+/// this session's would put every other session back where it started until
+/// that daemon happened to retire.
+const LEGACY_PID_FILE: &str = "updater.pid";
+
+/// Every session's updater pid file under the state dir, the legacy one
+/// included, sorted so callers behave the same run to run.
+///
+/// `--disable` is one decision for the whole machine — it writes the shared
+/// marker and takes our row out of the one config every session renders — so it
+/// has to reach the daemons other sessions started, not just this session's.
+pub fn pid_files() -> Vec<PathBuf> {
+    pid_files_in(&state_dir())
+}
+
+/// [`pid_files`] against an explicit dir, so a test can exercise it without the
+/// state dir the env decides. A dir we cannot read yields none, which is the
+/// same answer a dir with no updater in it gives.
+fn pid_files_in(dir: &std::path::Path) -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| is_pid_file(path))
+        .collect();
+    files.sort();
+    files
+}
+
+/// Whether `path` names an updater pid file — this scheme's or the legacy one.
+fn is_pid_file(path: &std::path::Path) -> bool {
+    match path.file_name().and_then(|name| name.to_str()) {
+        Some(name) => {
+            name == LEGACY_PID_FILE || (name.starts_with("updater-") && name.ends_with(".pid"))
+        }
+        None => false,
+    }
 }
 
 /// Marker recording what the user has *decided* about the updater
@@ -1172,6 +1231,64 @@ mod tests {
         // `[ ui ]` still counts as the ui table — the name is trimmed.
         let labels = parse_herdr_labels("[ ui ]\ncpu_label = X\n");
         assert_eq!(labels.cpu(), Some("X"));
+    }
+
+    // ---- state paths: one updater per session --------------------------------
+
+    #[test]
+    fn a_pid_file_is_named_for_one_session_only() {
+        // The state dir is shared by every session herdr runs, so the session
+        // key in the name is the only thing keeping two sessions' updaters
+        // apart. Same key, same file; different key, different file.
+        assert_eq!(pid_file_name("42c3c964"), "updater-42c3c964.pid");
+        assert_ne!(pid_file_name("42c3c964"), pid_file_name("e60b12c5"));
+    }
+
+    #[test]
+    fn a_sweep_finds_every_sessions_claim_and_the_legacy_one() {
+        // `--disable` is one decision for the whole machine, so it has to reach
+        // updaters this session never started — including the daemon left
+        // holding the un-keyed pid file an upgrade from before 1.11.1 stranded.
+        let dir = crate::testutil::scratch("pid-files");
+        for name in [
+            pid_file_name("aaaaaaaa"),
+            pid_file_name("bbbbbbbb"),
+            LEGACY_PID_FILE.to_string(),
+            // An empty key is still this scheme's shape — a socket path that
+            // could not be resolved. A file we cannot explain is safer swept
+            // than left holding a claim nothing ever releases.
+            "updater-.pid".to_string(),
+        ] {
+            std::fs::write(dir.join(name), "1\n").expect("fixture pid file");
+        }
+        // The rest of the state dir stays out of it: these record the user's
+        // decisions, not a process to stop.
+        for other in ["enabled", "bootstrapped", "updater.pid.bak"] {
+            std::fs::write(dir.join(other), "1\n").expect("fixture state file");
+        }
+
+        let found: Vec<String> = pid_files_in(&dir)
+            .iter()
+            .map(|path| path.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        // Sorted, so a caller behaves the same run to run.
+        assert_eq!(
+            found,
+            [
+                "updater-.pid",
+                "updater-aaaaaaaa.pid",
+                "updater-bbbbbbbb.pid",
+                LEGACY_PID_FILE,
+            ],
+        );
+    }
+
+    #[test]
+    fn a_state_dir_that_is_not_there_yields_no_claims() {
+        // A fresh install runs `--disable` before anything has written the dir.
+        // Nothing to stop is not an error.
+        let missing = crate::testutil::scratch("pid-files-missing").join("nope");
+        assert!(pid_files_in(&missing).is_empty());
     }
 
     // ---- shared helpers ------------------------------------------------------

--- a/src/config.rs
+++ b/src/config.rs
@@ -1245,6 +1245,23 @@ mod tests {
     }
 
     #[test]
+    fn this_sessions_claim_carries_this_sessions_key() {
+        // The wiring, not just the naming. Every other test here builds a name
+        // from a key by hand, so a `pid_file` that went back to a fixed name —
+        // and so to one updater for the whole machine — would sail past all of
+        // them. Host-independent: whatever socket this run resolves, the file
+        // has to be named after it and not after the pre-1.11.1 scheme.
+        let name = pid_file()
+            .file_name()
+            .expect("a pid file has a name")
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(name, pid_file_name(&crate::herdr::session_key()));
+        assert!(name.contains(&crate::herdr::session_key()), "got: {name}");
+        assert_ne!(name, LEGACY_PID_FILE);
+    }
+
+    #[test]
     fn a_sweep_finds_every_sessions_claim_and_the_legacy_one() {
         // `--disable` is one decision for the whole machine, so it has to reach
         // updaters this session never started — including the daemon left

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -346,14 +346,35 @@ pub fn run_daemon() -> crate::Result<()> {
         let config = &settings.config;
         let style = settings.row_style();
 
-        // Reinstalled or rebuilt underneath us? Then this process is the old
-        // version and nothing else will ever notice: herdr runs no hook on
-        // install or uninstall, and `--restore` — the one thing that fires
-        // afterwards — leaves any live daemon alone by design. So the daemon
-        // that is being replaced is the only party in a position to act, and it
-        // acts on itself. Doing it here rather than from the outside also keeps
-        // the single-instance claim honest: one process decides, releases, and
+        // Rebuilt underneath us? Then this process is the old version and
+        // nothing else will ever notice: herdr runs no hook on install or
+        // uninstall, and `--restore` — the one thing that fires afterwards —
+        // leaves any live daemon alone by design. So the daemon that is being
+        // replaced is the only party in a position to act, and it acts on
+        // itself. Doing it here rather than from the outside also keeps the
+        // single-instance claim honest: one process decides, releases, and
         // hands over, instead of two short-lived hooks racing to kill and spawn.
+        //
+        // REBUILT, though — not reinstalled. Measured against herdr 0.8.0: a
+        // `herdr plugin install` moves the whole checkout aside into a
+        // `.tmp-install-*/previous-checkout/` and deletes it, so this process's
+        // executable is not replaced at its path but unlinked from under it.
+        // `/proc/self/exe` then reads `<path> (deleted)`, `current_stamp` cannot
+        // stat it, and an unreadable stamp is deliberately not a change (see
+        // `build_changed` — guessing there would retire a healthy updater). A
+        // `cargo build` in the same tree, which is the dev-link workflow, does
+        // rewrite the file in place and IS caught.
+        //
+        // What that costs after a reinstall: this daemon keeps running the old
+        // build until its herdr server goes away. The new build is not blocked
+        // by it — each session's `--restore` claims its own pid file now and
+        // starts its own updater — so the sidebar is served by the new code and
+        // the old process is redundant rather than in the way. Before per-session
+        // claims it was the other way round, and worse: the old daemon held the
+        // one claim there was, so a reinstall did not take effect at all until
+        // the server restarted. Left as it is because the fix is not obviously
+        // safe — standing down on a vanished executable means `spawn_daemon`
+        // has no file to spawn either.
         if let Some(launched) = launched.as_deref() {
             if build_changed(launched, current_stamp().as_deref())
                 && !stopping.swap(true, Ordering::SeqCst)
@@ -1619,6 +1640,32 @@ mod tests {
             .map(|(_, claim)| claim.pid)
             .collect();
         assert_eq!(stopped, vec![4242, 4343]);
+    }
+
+    /// The Windows-only half of stopping another session's updater: there,
+    /// `--disable` terminates the process outright, so nothing inside it ever
+    /// unlinks its claim and this has to. Runs only where the code does — the
+    /// unix build has no such function, its daemons unlinking their own claim
+    /// from the SIGTERM handler.
+    ///
+    /// Worth having even though it is three lines: it was the one branch in
+    /// this change that nothing anywhere executed. CI compiles the Windows arm
+    /// and the tests exercised every other part of the path, which is a
+    /// combination that reads as covered and is not.
+    #[cfg(windows)]
+    #[test]
+    fn a_terminated_windows_daemon_has_its_claim_unlinked_for_it() {
+        let dir = scratch("stopped-claim");
+        let mine = claim(&dir, "42c3c964", 4242);
+        release_stopped_claim(&mine, 4242);
+        assert!(!mine.exists(), "the claim of the pid we stopped goes");
+
+        // A daemon started between listing the claims and stopping them owns
+        // its own file. Taking it would break the newcomer's single-instance
+        // guard and let a third updater start beside it.
+        let newcomer = claim(&dir, "e60b12c5", 4343);
+        release_stopped_claim(&newcomer, 4242);
+        assert!(newcomer.exists(), "a claim naming someone else stays");
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -464,7 +464,8 @@ pub fn disable_updater() -> crate::Result<()> {
     // config every session renders — are machine-wide, so leaving another
     // session's daemon running would have it push a token into a card that no
     // longer draws one, with nothing left to turn it off but a restart.
-    let mut sessions = vec![herdr::socket_path().ok()];
+    let mine = herdr::socket_path().ok();
+    let mut others = Vec::new();
     for (pid_file, claim) in recorded_claims() {
         if is_stoppable(&claim, is_our_process) {
             // Unix: SIGTERM, and the daemon clears its own statuses + title on
@@ -477,7 +478,9 @@ pub fn disable_updater() -> crate::Result<()> {
         // Swept either way. A claim whose process is already gone — a crash, a
         // SIGKILL, a session that ended badly — is the case where the rows are
         // certain to still be there and no daemon is left to take them back.
-        sessions.push(claim.socket);
+        if claim.socket != mine {
+            others.push(claim.socket);
+        }
     }
 
     // Belt and braces: sweep every pane of every session that ever recorded an
@@ -485,11 +488,48 @@ pub fn disable_updater() -> crate::Result<()> {
     // statuses, then clear each session's title. If herdr is unavailable,
     // metadata TTLs expire the statuses anyway; the pseudo-agent rows have no
     // TTL, so this is the only thing that takes them back.
-    sweep_sessions(sessions);
+    //
+    // Ours first, and the toast right behind it. This is the session the user
+    // is looking at and the only one known to be answering — the action came in
+    // over it — so it is both the sweep that matters and the one that cannot
+    // stall. Reporting after the foreign sweeps would hide a finished job
+    // behind a stranger's wedged socket.
     reap_dead_claims();
-
+    sweep_sessions(vec![mine]);
     notify("sidebar usage disabled");
+    sweep_other_sessions(others);
     Ok(())
+}
+
+/// How long `--disable` will wait on sessions other than its own, all together.
+///
+/// Generous next to the work — a healthy session is one snapshot and a handful
+/// of clears — because the deadline is there for a session that has stopped
+/// answering, not for a slow one.
+const OTHER_SESSION_SWEEP: Duration = Duration::from_secs(10);
+
+/// [`sweep_sessions`] for sessions that are not ours, under one deadline for
+/// the lot of them.
+///
+/// These sockets come out of files, and nothing has shown the servers behind
+/// them are alive. A session that has *gone* costs nothing — the connection is
+/// refused. The case to bound is a session that connects and then says nothing:
+/// unix caps each call at [`crate::herdr`]'s timeout, and Windows caps it at
+/// nothing at all, a pipe opened as a `File` having no timeout to set. Either
+/// way `--disable` is a command someone is waiting on, and it must not be a
+/// command that never returns.
+///
+/// So the work goes on a thread and the deadline is on the wait, not on any one
+/// call. Whatever is unfinished when time is up is abandoned — it dies with the
+/// process moments later, and what it would have cleared is a row the metadata
+/// TTL takes back anyway.
+fn sweep_other_sessions(sockets: Vec<Option<std::path::PathBuf>>) {
+    let (done, wait) = std::sync::mpsc::channel();
+    thread::spawn(move || {
+        sweep_sessions(sockets);
+        let _ = done.send(());
+    });
+    let _ = wait.recv_timeout(OTHER_SESSION_SWEEP);
 }
 
 /// Clear everything this plugin pushed into each named session, skipping any we
@@ -508,13 +548,13 @@ fn sweep_sessions(sockets: Vec<Option<std::path::PathBuf>>) {
         let Ok(mut client) = herdr::connect_to(socket) else {
             continue; // session gone, or a pre-1.11.1 claim that recorded none
         };
-        if let Ok(spaces) = collect::collect_spaces(&mut client) {
+        if let Ok(targets) = collect::sweep_targets(&mut client) {
             let mut sweep = Tracked::default();
-            for sp in &spaces {
-                sweep.pseudo.extend(sp.pseudo_panes.iter().cloned());
-                sweep.metadata.extend(sp.agent_panes.iter().cloned());
-                sweep.metadata.extend(sp.spare_panes.iter().cloned());
-                sweep.workspaces.insert(sp.id.clone());
+            for (workspace, panes) in targets {
+                sweep.pseudo.extend(panes.pseudo_panes);
+                sweep.metadata.extend(panes.agent_panes);
+                sweep.metadata.extend(panes.spare_panes);
+                sweep.workspaces.insert(workspace);
             }
             clear_all(&mut client, &sweep);
         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -404,6 +404,15 @@ pub fn disable_updater() -> crate::Result<()> {
 /// Reads this session rather than the machine so the action does what the
 /// sidebar in front of you shows: a session with no updater turns one on, even
 /// while another session has one running.
+///
+/// What it reads is per session; what it *does* is whatever the two halves do,
+/// and those are not symmetric. Toggling on starts this session's updater, and
+/// the others follow at their next `--restore`. Toggling off reaches every
+/// session, because there is no such thing as a session-local "off": one marker
+/// per user records the decision, and a session that tried to keep its own
+/// updater down would have `--restore` bring it back on the next space switch.
+/// Say so wherever this is documented — a user with two sessions who toggles one
+/// dark and finds both dark is owed the reason.
 pub fn toggle_updater() -> crate::Result<()> {
     if daemon_pid().is_some() {
         disable_updater()

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9,6 +9,15 @@
 //! a herdr or machine restart unless the `enabled` marker alongside the pid file
 //! says the user turned it off.
 //!
+//! One instance per *session*, not per machine. A daemon pushes over the one
+//! socket it connected to, so a second herdr session needs a second daemon; the
+//! pid file is therefore keyed by session (see [`config::pid_file`]) while the
+//! state dir it sits in — and so the `enabled` marker, the plugin config, and the
+//! row in herdr's own config — stays shared, because those are one decision for
+//! the whole machine. That split is what `--disable` follows: it stands down
+//! every session's updater, while `--enable` and `--restore` speak only for the
+//! session that ran them.
+//!
 //! That marker is tri-state, and the third state is the whole point: absent means
 //! *nobody has decided*, which is a fresh install, and a fresh install wants the
 //! updater. The old present/absent boolean could not tell that apart from a
@@ -96,27 +105,64 @@ fn reload_settings() -> Settings {
     }
 }
 
-/// PID of a live updater daemon, or `None` (missing pid file / dead process /
-/// a pid that no longer belongs to us).
+/// PID of a live updater daemon **for this herdr session**, or `None` (missing
+/// pid file / dead process / a pid that no longer belongs to us).
 ///
-/// Reads `<state_dir>/updater.pid` and confirms the pid is live AND really one
-/// of our processes ([`is_our_process`] answers both: a vanished pid has no
-/// image name to read). That second check matters: the state dir outlives
+/// Reads `<state_dir>/updater-<session>.pid` and confirms the pid is live AND
+/// really one of our processes ([`is_our_process`] answers both: a vanished pid
+/// has no image name to read). That second check matters: the state dir outlives
 /// reboots, so an unclean shutdown can leave a pid file pointing at a pid the
 /// kernel later recycled for something else — and without it `--enable` would
 /// no-op forever against that impostor, leaving the sidebar permanently blank.
+///
+/// Per session, not per machine: a daemon serves the one socket it connected to,
+/// so another session's live updater is no reason for this one to stand down.
+/// See [`config::pid_file`].
 pub fn daemon_pid() -> Option<u32> {
-    let pid = read_pid_file()?;
+    daemon_pid_at(&config::pid_file())
+}
+
+/// [`daemon_pid`] for an explicit pid file, so a test can put two sessions'
+/// claims side by side.
+fn daemon_pid_at(path: &std::path::Path) -> Option<u32> {
+    let pid = read_pid_file_at(path)?;
     is_our_process(pid).then_some(pid)
 }
 
-/// The pid recorded in `<state_dir>/updater.pid`, or `None` if the file is
+/// The pid recorded in this session's pid file, or `None` if the file is
 /// missing, unparseable, or holds a non-positive pid. Says nothing about
 /// whether that process is alive — [`daemon_pid`] adds that.
 fn read_pid_file() -> Option<u32> {
-    let text = std::fs::read_to_string(config::pid_file()).ok()?;
+    read_pid_file_at(&config::pid_file())
+}
+
+/// [`read_pid_file`] against an explicit path.
+fn read_pid_file_at(path: &std::path::Path) -> Option<u32> {
+    let text = std::fs::read_to_string(path).ok()?;
     let pid: i32 = text.trim().parse().ok()?;
     (pid > 0).then_some(pid as u32)
+}
+
+/// Every live updater on this machine, each paired with the pid file claiming
+/// it: this session's, every other session's, and the legacy global one.
+///
+/// Only `--disable` wants this. Everything else asks about *this* session, via
+/// [`daemon_pid`] — an updater that starts, hands over, or stands down on
+/// another session's account is the bug this pairing exists to keep out.
+fn live_updaters() -> Vec<(std::path::PathBuf, u32)> {
+    live_updaters_among(config::pid_files())
+}
+
+/// [`live_updaters`] over an explicit list of pid files, so a test can supply
+/// them instead of the state dir the env decides.
+fn live_updaters_among(pid_files: Vec<std::path::PathBuf>) -> Vec<(std::path::PathBuf, u32)> {
+    pid_files
+        .into_iter()
+        .filter_map(|path| {
+            let pid = read_pid_file_at(&path)?;
+            is_our_process(pid).then_some((path, pid))
+        })
+        .collect()
 }
 
 /// `--daemon`: run the updater loop until signalled, then clear and exit.
@@ -305,7 +351,7 @@ pub fn restore_updater() -> crate::Result<()> {
 }
 
 /// `--disable`: record that the updater is NOT wanted, take our config row back
-/// out, signal the daemon, and sweep any leftover statuses / title.
+/// out, signal every session's daemon, and sweep any leftover statuses / title.
 pub fn disable_updater() -> crate::Result<()> {
     // Record the intent so the restore hooks do not resurrect the updater on the
     // next herdr restart or space switch. This writes an explicit "off" rather
@@ -319,27 +365,17 @@ pub fn disable_updater() -> crate::Result<()> {
         reload_herdr_config();
     }
 
-    if let Some(pid) = daemon_pid() {
+    // Every session's updater, not just this one's. The two things `--disable`
+    // has just done — the shared marker and the row it took out of the one
+    // config every session renders — are machine-wide, so leaving another
+    // session's daemon running would have it push a token into a card that no
+    // longer draws one, with nothing left to turn it off but a restart.
+    for (pid_file, pid) in live_updaters() {
         // Unix: SIGTERM, and the daemon clears its own statuses + title on the
         // way down. Windows: TerminateProcess — abrupt, but the sweep below and
         // the status TTLs cover the cleanup the daemon can no longer do.
         proc::stop_process(pid);
-        // A terminated process runs no shutdown, so on Windows nothing would
-        // ever unlink the pid file: it outlives the daemon and leaves the
-        // recycled-pid check ([`is_our_process`]) as the only thing standing
-        // between a stale pid and a permanently no-op `--enable`. Deliberately
-        // NOT done on unix — there the daemon unlinks it from its own SIGTERM
-        // handler, and removing it out from under a daemon that is still
-        // shutting down would let an immediate `--enable` start a second one.
-        //
-        // Guarded on the file still naming the pid we just stopped: a daemon
-        // started in the window between `daemon_pid` and here owns its own file
-        // and must keep it, or this would silently break its single-instance
-        // guard.
-        #[cfg(windows)]
-        if claims_pid_file(read_pid_file(), pid) {
-            let _ = std::fs::remove_file(config::pid_file());
-        }
+        release_stopped_claim(&pid_file, pid);
     }
 
     // Belt and braces: sweep every current pane in case the daemon died — release
@@ -363,7 +399,11 @@ pub fn disable_updater() -> crate::Result<()> {
     Ok(())
 }
 
-/// `--toggle`: disable if a daemon is live, else enable.
+/// `--toggle`: disable if THIS session has a live daemon, else enable.
+///
+/// Reads this session rather than the machine so the action does what the
+/// sidebar in front of you shows: a session with no updater turns one on, even
+/// while another session has one running.
 pub fn toggle_updater() -> crate::Result<()> {
     if daemon_pid().is_some() {
         disable_updater()
@@ -670,6 +710,29 @@ fn claims_pid_file(recorded: Option<u32>, me: u32) -> bool {
     recorded == Some(me)
 }
 
+/// Give up the claim of a daemon `--disable` just terminated (Windows).
+///
+/// `TerminateProcess` runs no shutdown handler, so nothing else would ever
+/// unlink the pid file: it outlives the daemon and leaves the recycled-pid check
+/// ([`is_our_process`]) as the only thing standing between a stale pid and a
+/// permanently no-op `--enable`.
+///
+/// Guarded on the file still naming the pid we stopped: a daemon started in the
+/// window between [`live_updaters`] and here owns its own file and must keep it,
+/// or this would silently break its single-instance guard.
+#[cfg(windows)]
+fn release_stopped_claim(pid_file: &std::path::Path, pid: u32) {
+    if claims_pid_file(read_pid_file_at(pid_file), pid) {
+        let _ = std::fs::remove_file(pid_file);
+    }
+}
+
+/// Nothing to do on unix: the daemon unlinks its own pid file from its SIGTERM
+/// handler. Removing it out from under a daemon that is still shutting down
+/// would let an immediate `--enable` start a second one.
+#[cfg(not(windows))]
+fn release_stopped_claim(_pid_file: &std::path::Path, _pid: u32) {}
+
 /// Give up the single-instance claim, but only where it still names us.
 ///
 /// Every exit path this process has goes through here, so none of them can undo
@@ -888,6 +951,7 @@ mod tests {
     use super::*;
     use crate::battery::State;
     use crate::config::{Labels, RamDisplay};
+    use crate::testutil::scratch;
 
     fn space(cpu: f64, ram_mb: f64) -> Space {
         Space {
@@ -1153,19 +1217,6 @@ mod tests {
 
     // ---- restart recovery ---------------------------------------------------
 
-    /// Unique scratch dir under the system tmpdir, keyed by test name + pid so
-    /// parallel test threads never collide.
-    fn scratch(name: &str) -> std::path::PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "space-usage-test-{name}-{}-{:?}",
-            std::process::id(),
-            thread::current().id(),
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("scratch dir");
-        dir
-    }
-
     #[test]
     fn a_fresh_install_wants_the_daemon_without_anyone_asking() {
         // THE bug. A fresh install has written no marker, and the old present/
@@ -1264,5 +1315,75 @@ mod tests {
         // No image name to read for a dead pid — the stale-pid-file case must
         // read as "not ours" so the caller starts a fresh daemon.
         assert!(!is_our_process(u32::MAX));
+    }
+
+    // ---- one updater per session ---------------------------------------------
+
+    /// A pid file in `dir` claiming `pid`, named for `session_key`.
+    fn claim(dir: &std::path::Path, session_key: &str, pid: u32) -> std::path::PathBuf {
+        let path = dir.join(config::pid_file_name(session_key));
+        std::fs::write(&path, format!("{pid}\n")).expect("fixture pid file");
+        path
+    }
+
+    #[test]
+    fn one_sessions_live_updater_does_not_stand_the_next_session_down() {
+        // THE bug. herdr gives every session the same plugin state dir but its
+        // own socket, and a daemon pushes over the one socket it connected to.
+        // A single global claim therefore had the second session's `--restore`
+        // find the FIRST session's live updater, stand down, and leave its
+        // sidebar showing a `$usage` row with nothing in it — for as long as the
+        // other session stayed up.
+        let dir = scratch("two-sessions");
+        let me = std::process::id();
+        let first = claim(&dir, "42c3c964", me);
+        let second = dir.join(config::pid_file_name("e60b12c5"));
+
+        assert_eq!(daemon_pid_at(&first), Some(me), "the first session's own");
+        assert_eq!(
+            daemon_pid_at(&second),
+            None,
+            "the second session has to start one of its own",
+        );
+    }
+
+    #[test]
+    fn a_claim_survives_being_read_twice_by_the_session_that_holds_it() {
+        // The other half of the same guard: within ONE session the pid file
+        // still means "an updater is already live here", so `--restore` firing
+        // on every space switch does not pile daemons up.
+        let dir = scratch("same-session");
+        let mine = claim(&dir, "42c3c964", std::process::id());
+        assert!(daemon_pid_at(&mine).is_some());
+        assert!(daemon_pid_at(&mine).is_some());
+    }
+
+    #[test]
+    fn a_sweep_stops_every_live_session_and_leaves_the_dead_alone() {
+        // What `--disable` walks. It is one decision for the whole machine — it
+        // writes the shared marker and takes our row out of the one config every
+        // session renders — so a daemon another session started has to be
+        // stopped too, or it keeps pushing into a card that no longer draws it.
+        //
+        // A stale file is skipped rather than acted on: the state dir outlives
+        // reboots, so its pid may since have been recycled by an unrelated
+        // process, and `--disable` must not go killing that.
+        let dir = scratch("sweep");
+        let me = std::process::id();
+        let mine = claim(&dir, "42c3c964", me);
+        let other_session = claim(&dir, "e60b12c5", me);
+        let stale = claim(&dir, "deadbeef", u32::MAX);
+        let unparseable = dir.join(config::pid_file_name("garbage"));
+        std::fs::write(&unparseable, "not a pid\n").expect("fixture pid file");
+
+        assert_eq!(
+            live_updaters_among(vec![
+                mine.clone(),
+                other_session.clone(),
+                stale,
+                unparseable,
+            ]),
+            vec![(mine, me), (other_session, me)],
+        );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -532,6 +532,31 @@ fn sweep_other_sessions(sockets: Vec<Option<std::path::PathBuf>>) {
     let _ = wait.recv_timeout(OTHER_SESSION_SWEEP);
 }
 
+/// Everything one session could be carrying from us, as the set to clear.
+///
+/// A sweep runs where no record survives of what was actually pushed — another
+/// session's daemon kept that in its own memory and is now gone — so it assumes
+/// the most and clears it all. Clearing a pane we never touched is a no-op;
+/// missing one is a reading that stays on screen.
+///
+/// A pseudo pane goes in BOTH buckets, and that is the whole reason this is a
+/// function of its own. Agents-panel mode puts two things on that one pane —
+/// the pseudo-agent that names the row and the token that fills it (see
+/// [`push_statuses`]) — and listing it only as a pseudo released the row while
+/// leaving the reading behind it, on screen until the token's TTL ran out, in a
+/// session the user had just switched the overlay off in.
+fn everything_we_could_have_pushed(targets: Vec<(String, collect::PaneRoles)>) -> Tracked {
+    let mut sweep = Tracked::default();
+    for (workspace, panes) in targets {
+        sweep.metadata.extend(panes.pseudo_panes.iter().cloned());
+        sweep.pseudo.extend(panes.pseudo_panes);
+        sweep.metadata.extend(panes.agent_panes);
+        sweep.metadata.extend(panes.spare_panes);
+        sweep.workspaces.insert(workspace);
+    }
+    sweep
+}
+
 /// Clear everything this plugin pushed into each named session, skipping any we
 /// cannot reach and any we have already done.
 ///
@@ -549,14 +574,7 @@ fn sweep_sessions(sockets: Vec<Option<std::path::PathBuf>>) {
             continue; // session gone, or a pre-1.11.1 claim that recorded none
         };
         if let Ok(targets) = collect::sweep_targets(&mut client) {
-            let mut sweep = Tracked::default();
-            for (workspace, panes) in targets {
-                sweep.pseudo.extend(panes.pseudo_panes);
-                sweep.metadata.extend(panes.agent_panes);
-                sweep.metadata.extend(panes.spare_panes);
-                sweep.workspaces.insert(workspace);
-            }
-            clear_all(&mut client, &sweep);
+            clear_all(&mut client, &everything_we_could_have_pushed(targets));
         }
         let _ = client.window_title_clear();
     }
@@ -1585,6 +1603,37 @@ mod tests {
             .map(|(_, claim)| claim.pid)
             .collect();
         assert_eq!(stopped, vec![4242, 4343]);
+    }
+
+    #[test]
+    fn a_sweep_takes_back_both_things_a_pseudo_pane_carries() {
+        // Found end-to-end, in agents-panel mode across two sessions: the sweep
+        // released the pseudo-agent row and left the reading sitting inside it,
+        // because the pane went into the pseudo bucket only. It cleared itself
+        // 15 s later when the token's TTL ran out — a stale figure in a session
+        // the user had just switched the overlay off in, and in the one mode
+        // where nothing else was going to clean up after another session's
+        // daemon.
+        let sweep = everything_we_could_have_pushed(vec![(
+            "w1".to_string(),
+            collect::PaneRoles {
+                cwd: None,
+                pseudo_panes: vec!["w1:p1".to_string()],
+                agent_panes: vec!["w1:p2".to_string()],
+                spare_panes: vec!["w1:p3".to_string()],
+            },
+        )]);
+
+        assert!(sweep.pseudo.contains("w1:p1"), "the row is released");
+        assert!(
+            sweep.metadata.contains("w1:p1"),
+            "and the reading inside it is cleared, not left to its TTL",
+        );
+        // The other two carry a token and no pseudo-agent.
+        assert_eq!(sweep.pseudo.len(), 1);
+        assert!(sweep.metadata.contains("w1:p2") && sweep.metadata.contains("w1:p3"));
+        // Sidebar mode reports at the workspace level, so that has to go too.
+        assert!(sweep.workspaces.contains("w1"));
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -335,6 +335,27 @@ pub fn run_daemon() -> crate::Result<()> {
     let mut failures: u32 = 0;
     loop {
         heartbeat.store(started.elapsed().as_secs(), Ordering::SeqCst);
+        // Still the updater this session recognises? The claim above is written
+        // after a check, and two `--restore` hooks firing together can both pass
+        // that check before either writes — herdr fires one on every
+        // `workspace.focused`, so a fast pair of space switches is all it takes.
+        // The second write then overwrote the first daemon's claim, and THAT is
+        // the state worth guarding against: a daemon nothing can see. It appears
+        // in no pid file, so `--disable` never signals it, the reaper never
+        // touches it, and `--restore` never counts it — while it goes on pushing
+        // rows and titles every interval. `--toggle` made it worse, reading the
+        // absent claim as "nothing running" and starting yet another.
+        //
+        // One line of arithmetic settles it: whoever the file names is the
+        // updater, and everyone else stands down at their next cycle. Two
+        // daemons converge to one within an interval whichever order they wrote
+        // in, and a daemon whose claim was removed by `--disable` exits too,
+        // which is how a `--disable` reaches one of these at all.
+        if !claims_pid_file(read_pid_file(), std::process::id())
+            && !stopping.swap(true, Ordering::SeqCst)
+        {
+            stand_down();
+        }
         // Pick up config edits without an updater restart. Two small file reads
         // per refresh, against a cadence measured in seconds — far cheaper than
         // the `/proc` walk that just ran, and it is what keeps the sidebar rows
@@ -472,7 +493,7 @@ pub fn disable_updater() -> crate::Result<()> {
     // next herdr restart or space switch. This writes an explicit "off" rather
     // than deleting the marker: an absent marker now means "fresh install", and
     // deleting it would make every disable undo itself on the next restart.
-    set_wanted(&config::enabled_flag(), Wanted::Disabled);
+    let recorded = set_wanted(&config::enabled_flag(), Wanted::Disabled);
     // Reversible, as promised: whatever we added to herdr's config comes out —
     // and taking it out un-does the first-run setup, so let that setup run again.
     if herdr_config::remove_usage_row().is_ok_and(Change::needs_reload) {
@@ -517,7 +538,7 @@ pub fn disable_updater() -> crate::Result<()> {
     // behind a stranger's wedged socket.
     reap_dead_claims();
     sweep_sessions(vec![mine]);
-    notify("sidebar usage disabled");
+    notify(disabled_message(recorded));
     sweep_other_sessions(others);
     Ok(())
 }
@@ -832,19 +853,22 @@ fn spawn_daemon() -> crate::Result<()> {
 /// "off" would make every `--disable` undo itself at the next restart.
 ///
 /// Best-effort: the marker only drives restart recovery, so a state dir we cannot
-/// write must not fail the enable/disable the user actually asked for.
-fn set_wanted(path: &std::path::Path, wanted: Wanted) {
+/// write must not fail the enable/disable the user actually asked for. It does
+/// report whether it landed, because for `--disable` a marker that did not is
+/// worth saying out loud — see [`disable_updater`].
+fn set_wanted(path: &std::path::Path, wanted: Wanted) -> bool {
     if let Some(dir) = path.parent() {
         let _ = std::fs::create_dir_all(dir);
     }
-    let _ = std::fs::write(
+    std::fs::write(
         path,
         if wanted == Wanted::Disabled {
             "0\n"
         } else {
             "1\n"
         },
-    );
+    )
+    .is_ok()
 }
 
 /// One-time setup: make herdr's sidebar draw the token this plugin pushes.
@@ -911,6 +935,23 @@ fn forget_bootstrap_at(marker: &std::path::Path) {
 fn reload_herdr_config() {
     if let Ok(mut client) = herdr::connect() {
         let _ = client.server_reload_config();
+    }
+}
+
+/// Toast text for `--disable`, saying so when the decision did not stick.
+///
+/// An unwritable state dir makes this action quietly self-undoing: the row comes
+/// out and the updaters stop, but with no marker to read, the next space switch
+/// sees a fresh install, puts the row back, and starts an updater again. Silence
+/// there would have the overlay reappear minutes after someone turned it off,
+/// with nothing to connect the two.
+fn disabled_message(recorded: bool) -> &'static str {
+    match recorded {
+        true => "sidebar usage disabled",
+        false => {
+            "sidebar usage disabled for now — the plugin's state dir is not \
+                  writable, so it will come back on the next space switch"
+        }
     }
 }
 
@@ -1048,6 +1089,17 @@ fn is_our_process(pid: u32) -> bool {
 fn shutdown(client: Option<&mut Herdr>, tracked: &Mutex<Tracked>) -> ! {
     release(client, tracked);
     std::process::exit(0);
+}
+
+/// Exit, clearing nothing and releasing nothing.
+///
+/// For the daemon that finds another one holding this session's claim. What is
+/// on screen is the claim-holder's work now, so clearing it would blank the
+/// sidebar for a cycle on our way out, and the pid file is not ours to unlink —
+/// [`release_pid_claim`] would decline anyway, which is the same judgement made
+/// twice. Just go.
+fn stand_down() -> ! {
+    std::process::exit(0)
 }
 
 /// Stand down in favour of a replacement built from the binary now on disk.
@@ -1224,6 +1276,46 @@ mod tests {
         assert!(claims_pid_file(Some(42), 42));
         assert!(!claims_pid_file(Some(43), 42));
         assert!(!claims_pid_file(None, 42));
+    }
+
+    #[test]
+    fn only_the_daemon_the_claim_names_keeps_running() {
+        // The rule the loop applies every cycle, and the answer to a daemon
+        // nothing can see. Two `--restore` hooks firing together can both pass
+        // the startup check before either writes, and the second write leaves
+        // the first daemon with no claim: absent from every pid file, so
+        // `--disable` cannot signal it, the reaper cannot find it, and
+        // `--toggle` reads the missing claim as "nothing running" and starts a
+        // third. It pushed rows for as long as its herdr lived.
+        //
+        // Now the file decides. Whoever it names stays; everyone else goes at
+        // their next cycle, in whichever order they wrote.
+        let me = std::process::id();
+        assert!(claims_pid_file(Some(me), me), "the claim holder stays");
+        assert!(
+            !claims_pid_file(Some(me + 1), me),
+            "a daemon whose claim was taken stands down",
+        );
+        // And the case that lets `--disable` reach one at all: it stops the
+        // claim holder, which unlinks the file on its way out, and the daemon
+        // that had no claim then finds nothing naming it either.
+        assert!(
+            !claims_pid_file(None, me),
+            "an unlinked claim stands the rest down too",
+        );
+    }
+
+    #[test]
+    fn a_disable_that_could_not_record_itself_says_so() {
+        // Otherwise the action is quietly self-undoing: the row comes out and
+        // the updaters stop, but with no marker the next space switch reads a
+        // fresh install, puts the row back and starts an updater — the overlay
+        // returning minutes later with nothing to connect it to.
+        let ok = disabled_message(true);
+        let failed = disabled_message(false);
+        assert_eq!(ok, "sidebar usage disabled");
+        assert!(failed.starts_with(ok), "got: {failed}");
+        assert!(failed.contains("come back"), "got: {failed}");
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -175,22 +175,48 @@ fn read_pid_file_at(path: &std::path::Path) -> Option<u32> {
 fn read_claim_at(path: &std::path::Path) -> Option<Claim> {
     let text = std::fs::read_to_string(path).ok()?;
     let mut lines = text.lines();
-    // Parsed wide, then bounded, so the accepted set is exactly the pids a pid
-    // can be. The old `i32` parse rejected everything above 2^31 — which no
-    // Linux pid reaches (`pid_max` caps far below it) but a Windows one may,
-    // pids there being a full 32 bits. A daemon whose own pid its own reader
-    // threw out would hold a claim nothing could see, and the single-instance
-    // guard would be off for that process's whole life.
-    let pid: u64 = lines.next()?.trim().parse().ok()?;
+    let pid = claimed_pid(lines.next()?)?;
     let socket = lines
         .next()
         .map(str::trim)
         .filter(|line| !line.is_empty())
         .map(std::path::PathBuf::from);
-    (pid > 0 && pid <= u64::from(u32::MAX)).then_some(Claim {
-        pid: pid as u32,
-        socket,
-    })
+    Some(Claim { pid, socket })
+}
+
+/// The pid a claim's first line names, if it names one a pid can be.
+///
+/// Parsed wide, then bounded, so the accepted set is exactly the pids a pid can
+/// be. The old `i32` parse rejected everything above 2^31 — which no Linux pid
+/// reaches (`pid_max` caps far below it) but a Windows one may, pids there being
+/// a full 32 bits. A daemon whose own pid its own reader threw out would hold a
+/// claim nothing could see, and the single-instance guard would be off for that
+/// process's whole life.
+fn claimed_pid(line: &str) -> Option<u32> {
+    let pid: u64 = line.trim().parse().ok()?;
+    (pid > 0 && pid <= u64::from(u32::MAX)).then_some(pid as u32)
+}
+
+/// Whether this session's claim still names us — `None` when the file could not
+/// be read at all.
+///
+/// The three answers are the point, and the loop acts on only one of them. A
+/// file that is GONE is a definite no: `--disable` unlinks it, and that is what
+/// stands a daemon down. A file naming someone else is a definite no as well.
+/// But a read that FAILS for any other reason — a state dir on a networked home
+/// gone stale, a process out of descriptors — says nothing about who holds the
+/// claim, and answering "not you" there would exit a perfectly healthy solo
+/// updater over a blip.
+///
+/// The same judgement [`build_changed`] makes about a stat it could not take:
+/// where the question is "has something changed underneath me", not being able
+/// to look is not evidence that it has.
+fn claim_still_ours(path: &std::path::Path) -> Option<bool> {
+    match std::fs::read_to_string(path) {
+        Ok(text) => Some(text.lines().next().and_then(claimed_pid) == Some(std::process::id())),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Some(false),
+        Err(_) => None,
+    }
 }
 
 /// Every claim recorded under the state dir, live or not, each with the pid
@@ -351,7 +377,10 @@ pub fn run_daemon() -> crate::Result<()> {
         // daemons converge to one within an interval whichever order they wrote
         // in, and a daemon whose claim was removed by `--disable` exits too,
         // which is how a `--disable` reaches one of these at all.
-        if !claims_pid_file(read_pid_file(), std::process::id())
+        //
+        // Only a definite answer counts — see [`claim_still_ours`]. A file we
+        // could not read is not a file that named someone else.
+        if claim_still_ours(&config::pid_file()) == Some(false)
             && !stopping.swap(true, Ordering::SeqCst)
         {
             stand_down();
@@ -1276,6 +1305,37 @@ mod tests {
         assert!(claims_pid_file(Some(42), 42));
         assert!(!claims_pid_file(Some(43), 42));
         assert!(!claims_pid_file(None, 42));
+    }
+
+    #[test]
+    fn a_claim_that_cannot_be_read_stands_nobody_down() {
+        // Three answers, and the loop acts on one. Gone and taken are both
+        // definite; a read that failed for any other reason is not, and
+        // treating it as "taken" would exit a healthy solo updater over a
+        // networked home going stale for a moment. Same judgement
+        // `build_changed` makes about a stat it could not take.
+        let dir = scratch("claim-readable");
+        let me = std::process::id();
+
+        let mine = claim(&dir, "42c3c964", me);
+        assert_eq!(claim_still_ours(&mine), Some(true), "ours");
+
+        let theirs = claim(&dir, "e60b12c5", me + 1);
+        assert_eq!(claim_still_ours(&theirs), Some(false), "taken");
+
+        let gone = dir.join(config::pid_file_name("deadbeef"));
+        assert_eq!(
+            claim_still_ours(&gone),
+            Some(false),
+            "unlinked by --disable"
+        );
+
+        // A directory where the file should be: readable as an entry, never as
+        // text. Stands in for the read errors a test cannot arrange — the point
+        // is only that a non-NotFound failure answers "cannot tell".
+        let unreadable = dir.join(config::pid_file_name("0badc0de"));
+        std::fs::create_dir(&unreadable).expect("fixture dir");
+        assert_eq!(claim_still_ours(&unreadable), None, "cannot tell");
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -129,6 +129,31 @@ fn daemon_pid_at(path: &std::path::Path) -> Option<u32> {
     is_our_process(pid).then_some(pid)
 }
 
+/// What one updater's pid file says: the process holding the claim, and the
+/// herdr socket it serves.
+///
+/// The socket rides along because a claim is only useful to another session if
+/// it can be acted on, and every action worth taking — clearing a status,
+/// clearing a title — goes over that session's own socket. It is `None` for a
+/// file written before 1.11.1, which recorded the pid alone.
+#[derive(Debug, PartialEq, Eq)]
+struct Claim {
+    pid: u32,
+    socket: Option<std::path::PathBuf>,
+}
+
+/// Record this process's claim on `path`: its pid, and the socket it serves.
+///
+/// Two lines rather than one so the first stays exactly what it always was. The
+/// only reader that could be surprised is an OLDER build parsing the whole file
+/// as a number — a downgrade, which would read the file as unclaimed and start
+/// a second updater in that one session. Both push the same rows, and the next
+/// upgrade settles it.
+fn write_claim(path: &std::path::Path, socket: Option<&std::path::Path>) -> std::io::Result<()> {
+    let socket = socket.map(|s| s.display().to_string()).unwrap_or_default();
+    std::fs::write(path, format!("{}\n{socket}\n", std::process::id()))
+}
+
 /// The pid recorded in this session's pid file, or `None` if the file is
 /// missing, unparseable, or holds a non-positive pid. Says nothing about
 /// whether that process is alive — [`daemon_pid`] adds that.
@@ -138,31 +163,96 @@ fn read_pid_file() -> Option<u32> {
 
 /// [`read_pid_file`] against an explicit path.
 fn read_pid_file_at(path: &std::path::Path) -> Option<u32> {
-    let text = std::fs::read_to_string(path).ok()?;
-    let pid: i32 = text.trim().parse().ok()?;
-    (pid > 0).then_some(pid as u32)
+    Some(read_claim_at(path)?.pid)
 }
 
-/// Every live updater on this machine, each paired with the pid file claiming
-/// it: this session's, every other session's, and the legacy global one.
+/// Parse the claim recorded at `path`.
+///
+/// First line only for the pid, so the socket line below it cannot turn a
+/// perfectly good claim into "no updater here" — that answer starts a second
+/// daemon. An empty or absent second line is a claim we can identify but not
+/// reach, which is what a pre-1.11.1 file is.
+fn read_claim_at(path: &std::path::Path) -> Option<Claim> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let mut lines = text.lines();
+    // Parsed wide, then bounded, so the accepted set is exactly the pids a pid
+    // can be. The old `i32` parse rejected everything above 2^31 — which no
+    // Linux pid reaches (`pid_max` caps far below it) but a Windows one may,
+    // pids there being a full 32 bits. A daemon whose own pid its own reader
+    // threw out would hold a claim nothing could see, and the single-instance
+    // guard would be off for that process's whole life.
+    let pid: u64 = lines.next()?.trim().parse().ok()?;
+    let socket = lines
+        .next()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(std::path::PathBuf::from);
+    (pid > 0 && pid <= u64::from(u32::MAX)).then_some(Claim {
+        pid: pid as u32,
+        socket,
+    })
+}
+
+/// Every claim recorded under the state dir, live or not, each with the pid
+/// file holding it: this session's, every other session's, and the legacy
+/// global one.
 ///
 /// Only `--disable` wants this. Everything else asks about *this* session, via
 /// [`daemon_pid`] — an updater that starts, hands over, or stands down on
 /// another session's account is the bug this pairing exists to keep out.
-fn live_updaters() -> Vec<(std::path::PathBuf, u32)> {
-    live_updaters_among(config::pid_files())
+///
+/// Dead claims come back too, and are worth having: the socket a crashed daemon
+/// recorded is the only way left to take back the rows it pushed, and in
+/// agents-panel mode those rows carry no TTL to fall back on.
+fn recorded_claims() -> Vec<(std::path::PathBuf, Claim)> {
+    recorded_claims_among(config::pid_files())
 }
 
-/// [`live_updaters`] over an explicit list of pid files, so a test can supply
-/// them instead of the state dir the env decides.
-fn live_updaters_among(pid_files: Vec<std::path::PathBuf>) -> Vec<(std::path::PathBuf, u32)> {
+/// [`recorded_claims`] over an explicit list of pid files, so a test can supply
+/// them instead of the state dir the environment decides.
+fn recorded_claims_among(pid_files: Vec<std::path::PathBuf>) -> Vec<(std::path::PathBuf, Claim)> {
     pid_files
         .into_iter()
-        .filter_map(|path| {
-            let pid = read_pid_file_at(&path)?;
-            is_our_process(pid).then_some((path, pid))
-        })
+        .filter_map(|path| Some((path.clone(), read_claim_at(&path)?)))
         .collect()
+}
+
+/// Whether `claim` names an updater that `--disable` should stop.
+///
+/// `is_live` is a parameter because the real one, [`is_our_process`], looks for
+/// a live process running our own image — which no portable test can conjure a
+/// second of.
+///
+/// Our own pid is not an updater, however convincingly a file claims it is.
+/// `--disable` runs the same executable the daemon does, so [`is_our_process`]
+/// cannot tell them apart, and a stale file the kernel has since recycled onto
+/// THIS process would have `--disable` stop itself half way through — after
+/// writing the marker and removing the row, before clearing a single status.
+fn is_stoppable(claim: &Claim, is_live: impl Fn(u32) -> bool) -> bool {
+    claim.pid != std::process::id() && is_live(claim.pid)
+}
+
+/// Unlink every pid file that names no live process of ours.
+///
+/// A daemon releases its own claim on the way out, so these are the ones that
+/// never got the chance: a SIGKILL, a crash, a power cut. Left alone they
+/// accumulate one per session ever run, and each is a lottery ticket in the
+/// recycled-pid draw [`is_our_process`] cannot see through — a pid landing on
+/// the user's own dashboard pane reads as an updater. Reaping them is safe by
+/// definition: the file names nothing.
+fn reap_dead_claims() {
+    reap_dead_claims_among(config::pid_files(), is_our_process);
+}
+
+/// [`reap_dead_claims`] over an explicit list and liveness test — same seam, and
+/// there for the same reason, as [`live_updaters_among`].
+fn reap_dead_claims_among(pid_files: Vec<std::path::PathBuf>, is_live: impl Fn(u32) -> bool) {
+    for path in pid_files {
+        let live = read_claim_at(&path).is_some_and(|claim| is_live(claim.pid));
+        if !live {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
 }
 
 /// `--daemon`: run the updater loop until signalled, then clear and exit.
@@ -177,7 +267,11 @@ pub fn run_daemon() -> crate::Result<()> {
         return Ok(()); // another updater is already live
     }
     std::fs::create_dir_all(config::state_dir())?;
-    std::fs::write(config::pid_file(), format!("{}\n", std::process::id()))?;
+    // The socket goes in beside the pid so a `--disable` run from another
+    // session can clear what this daemon pushed. Nothing else can: it is
+    // reached over this socket, and on Windows a terminated daemon runs no
+    // shutdown of its own.
+    write_claim(&config::pid_file(), herdr::socket_path().ok().as_deref())?;
     // Taken once, before any work: this is the build we are, and the loop
     // compares it against the file on disk to notice being replaced.
     let launched = current_stamp();
@@ -370,18 +464,50 @@ pub fn disable_updater() -> crate::Result<()> {
     // config every session renders — are machine-wide, so leaving another
     // session's daemon running would have it push a token into a card that no
     // longer draws one, with nothing left to turn it off but a restart.
-    for (pid_file, pid) in live_updaters() {
-        // Unix: SIGTERM, and the daemon clears its own statuses + title on the
-        // way down. Windows: TerminateProcess — abrupt, but the sweep below and
-        // the status TTLs cover the cleanup the daemon can no longer do.
-        proc::stop_process(pid);
-        release_stopped_claim(&pid_file, pid);
+    let mut sessions = vec![herdr::socket_path().ok()];
+    for (pid_file, claim) in recorded_claims() {
+        if is_stoppable(&claim, is_our_process) {
+            // Unix: SIGTERM, and the daemon clears its own statuses + title on
+            // the way down. Windows: TerminateProcess — abrupt, so the sweep
+            // below does that daemon's cleaning for it, over the socket it
+            // recorded.
+            proc::stop_process(claim.pid);
+            release_stopped_claim(&pid_file, claim.pid);
+        }
+        // Swept either way. A claim whose process is already gone — a crash, a
+        // SIGKILL, a session that ended badly — is the case where the rows are
+        // certain to still be there and no daemon is left to take them back.
+        sessions.push(claim.socket);
     }
 
-    // Belt and braces: sweep every current pane in case the daemon died — release
-    // pseudo-agents (no TTL) and clear metadata statuses — then clear the title.
-    // If herdr is unavailable, metadata TTLs expire the statuses anyway.
-    if let Ok(mut client) = herdr::connect() {
+    // Belt and braces: sweep every pane of every session that ever recorded an
+    // updater, plus our own — release pseudo-agents (no TTL) and clear metadata
+    // statuses, then clear each session's title. If herdr is unavailable,
+    // metadata TTLs expire the statuses anyway; the pseudo-agent rows have no
+    // TTL, so this is the only thing that takes them back.
+    sweep_sessions(sessions);
+    reap_dead_claims();
+
+    notify("sidebar usage disabled");
+    Ok(())
+}
+
+/// Clear everything this plugin pushed into each named session, skipping any we
+/// cannot reach and any we have already done.
+///
+/// One session per socket, because a status can only be cleared over the
+/// connection that set it. On unix the daemons clear up after themselves and
+/// this is the belt to that pair of braces; on Windows they are terminated
+/// outright and this is the only cleaning that happens at all.
+fn sweep_sessions(sockets: Vec<Option<std::path::PathBuf>>) {
+    let mut done = HashSet::new();
+    for socket in sockets.into_iter().flatten() {
+        if !done.insert(socket.clone()) {
+            continue;
+        }
+        let Ok(mut client) = herdr::connect_to(socket) else {
+            continue; // session gone, or a pre-1.11.1 claim that recorded none
+        };
         if let Ok(spaces) = collect::collect_spaces(&mut client) {
             let mut sweep = Tracked::default();
             for sp in &spaces {
@@ -394,9 +520,6 @@ pub fn disable_updater() -> crate::Result<()> {
         }
         let _ = client.window_title_clear();
     }
-
-    notify("sidebar usage disabled");
-    Ok(())
 }
 
 /// `--toggle`: disable if THIS session has a live daemon, else enable.
@@ -727,8 +850,8 @@ fn claims_pid_file(recorded: Option<u32>, me: u32) -> bool {
 /// permanently no-op `--enable`.
 ///
 /// Guarded on the file still naming the pid we stopped: a daemon started in the
-/// window between [`live_updaters`] and here owns its own file and must keep it,
-/// or this would silently break its single-instance guard.
+/// window between [`recorded_claims`] and here owns its own file and must keep
+/// it, or this would silently break its single-instance guard.
 #[cfg(windows)]
 fn release_stopped_claim(pid_file: &std::path::Path, pid: u32) {
     if claims_pid_file(read_pid_file_at(pid_file), pid) {
@@ -1328,11 +1451,21 @@ mod tests {
 
     // ---- one updater per session ---------------------------------------------
 
-    /// A pid file in `dir` claiming `pid`, named for `session_key`.
+    /// A pid file in `dir` claiming `pid` for `session_key`, in the two-line
+    /// form a 1.11.1 daemon writes.
     fn claim(dir: &std::path::Path, session_key: &str, pid: u32) -> std::path::PathBuf {
         let path = dir.join(config::pid_file_name(session_key));
-        std::fs::write(&path, format!("{pid}\n")).expect("fixture pid file");
+        std::fs::write(&path, format!("{pid}\n/run/{session_key}.sock\n"))
+            .expect("fixture pid file");
         path
+    }
+
+    /// The claim `claim` writes, for comparing against what was read back.
+    fn claim_of(session_key: &str, pid: u32) -> Claim {
+        Claim {
+            pid,
+            socket: Some(std::path::PathBuf::from(format!("/run/{session_key}.sock"))),
+        }
     }
 
     #[test]
@@ -1357,42 +1490,137 @@ mod tests {
     }
 
     #[test]
-    fn a_claim_survives_being_read_twice_by_the_session_that_holds_it() {
-        // The other half of the same guard: within ONE session the pid file
-        // still means "an updater is already live here", so `--restore` firing
-        // on every space switch does not pile daemons up.
-        let dir = scratch("same-session");
-        let mine = claim(&dir, "42c3c964", std::process::id());
-        assert!(daemon_pid_at(&mine).is_some());
-        assert!(daemon_pid_at(&mine).is_some());
-    }
-
-    #[test]
-    fn a_sweep_stops_every_live_session_and_leaves_the_dead_alone() {
-        // What `--disable` walks. It is one decision for the whole machine — it
-        // writes the shared marker and takes our row out of the one config every
-        // session renders — so a daemon another session started has to be
+    fn disable_stops_the_live_updaters_but_sweeps_every_session_it_can_name() {
+        // What `--disable` acts on. It is one decision for the whole machine —
+        // it writes the shared marker and takes our row out of the one config
+        // every session renders — so a daemon another session started has to be
         // stopped too, or it keeps pushing into a card that no longer draws it.
         //
-        // A stale file is skipped rather than acted on: the state dir outlives
-        // reboots, so its pid may since have been recycled by an unrelated
-        // process, and `--disable` must not go killing that.
+        // Three kinds are never stopped. A stale pid, because the state dir
+        // outlives reboots and the kernel may since have recycled it onto
+        // something else. An unparseable file, because it names nothing. And
+        // our own pid: `--disable` runs the same executable the daemon does, so
+        // a recycled pid landing HERE would have it stop itself half way
+        // through, having written the marker and removed the row but cleared
+        // not one status.
+        //
+        // The stale one is still SWEPT, which is the half that is easy to get
+        // wrong: a daemon that crashed left its rows behind and no longer has a
+        // process to take them back, and in agents-panel mode those rows have
+        // no TTL to fall back on. Its socket is the only way to reach them, and
+        // its pid file is the only place that socket is written down.
         let dir = scratch("sweep");
-        let me = std::process::id();
-        let mine = claim(&dir, "42c3c964", me);
-        let other_session = claim(&dir, "e60b12c5", me);
+        // Everything is live to this liveness test EXCEPT the pid nothing can
+        // be running under, so what the assertions pin is the code's own doing.
+        let is_live = |pid: u32| pid != u32::MAX;
+        let mine = claim(&dir, "42c3c964", 4242);
+        let other_session = claim(&dir, "e60b12c5", 4343);
         let stale = claim(&dir, "deadbeef", u32::MAX);
+        let ourselves = claim(&dir, "0badc0de", std::process::id());
         let unparseable = dir.join(config::pid_file_name("garbage"));
         std::fs::write(&unparseable, "not a pid\n").expect("fixture pid file");
 
+        let claims = recorded_claims_among(vec![
+            mine.clone(),
+            other_session.clone(),
+            stale.clone(),
+            ourselves.clone(),
+            unparseable,
+        ]);
+
+        // Every readable claim, so every session's socket is reachable.
         assert_eq!(
-            live_updaters_among(vec![
-                mine.clone(),
-                other_session.clone(),
-                stale,
-                unparseable,
-            ]),
-            vec![(mine, me), (other_session, me)],
+            claims,
+            vec![
+                (mine, claim_of("42c3c964", 4242)),
+                (other_session, claim_of("e60b12c5", 4343)),
+                (stale, claim_of("deadbeef", u32::MAX)),
+                (ourselves, claim_of("0badc0de", std::process::id())),
+            ],
         );
+        // Of those, only the two live ones that are not us get stopped.
+        let stopped: Vec<u32> = claims
+            .iter()
+            .filter(|(_, claim)| is_stoppable(claim, is_live))
+            .map(|(_, claim)| claim.pid)
+            .collect();
+        assert_eq!(stopped, vec![4242, 4343]);
+    }
+
+    #[test]
+    fn a_claim_carries_the_socket_the_daemon_serves() {
+        // The half that makes a cross-session `--disable` able to clean up at
+        // all: statuses are cleared over the connection that set them, and on
+        // Windows a terminated daemon clears nothing itself. A file from before
+        // 1.11.1 names a pid and no socket — still a claim, just one we can
+        // stop without being able to tidy after.
+        let dir = scratch("claim-format");
+        let path = dir.join("updater-42c3c964.pid");
+
+        write_claim(&path, Some(std::path::Path::new("/run/a.sock"))).unwrap();
+        assert_eq!(
+            read_claim_at(&path),
+            Some(Claim {
+                pid: std::process::id(),
+                socket: Some("/run/a.sock".into()),
+            }),
+        );
+
+        // A second line that is absent or blank reads as "no socket recorded",
+        // never as a broken claim — answering "no updater here" would start a
+        // second one.
+        for legacy in ["4242\n", "4242", "4242\n\n"] {
+            std::fs::write(&path, legacy).unwrap();
+            assert_eq!(
+                read_claim_at(&path),
+                Some(Claim {
+                    pid: 4242,
+                    socket: None
+                }),
+                "got: {legacy:?}",
+            );
+        }
+
+        // The whole pid range, and nothing outside it. Windows pids are a full
+        // 32 bits, so the top of the range is an ordinary pid there, not the
+        // impossible value it looks like on Linux — and a claim thrown out for
+        // being too large is a single-instance guard that never engages.
+        for (text, expected) in [
+            ("4294967295\n", Some(u32::MAX)),
+            ("4294967296\n", None),
+            ("0\n", None),
+            ("-1\n", None),
+            ("\n", None),
+            ("", None),
+        ] {
+            std::fs::write(&path, text).unwrap();
+            assert_eq!(
+                read_claim_at(&path).map(|claim| claim.pid),
+                expected,
+                "got: {text:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn reaping_takes_the_claims_that_name_nothing_and_leaves_the_rest() {
+        // Left alone these accumulate one per session ever run, and each is a
+        // ticket in the recycled-pid draw `is_our_process` cannot see through.
+        // Reaping is safe by definition: the file names no live process of ours.
+        let dir = scratch("reap");
+        let is_live = |pid: u32| pid != u32::MAX;
+        let live = claim(&dir, "42c3c964", 4242);
+        let dead = claim(&dir, "deadbeef", u32::MAX);
+        let unparseable = dir.join(config::pid_file_name("garbage"));
+        std::fs::write(&unparseable, "not a pid\n").expect("fixture pid file");
+
+        reap_dead_claims_among(
+            vec![live.clone(), dead.clone(), unparseable.clone()],
+            is_live,
+        );
+
+        assert!(live.exists(), "a live updater keeps its claim");
+        assert!(!dead.exists(), "a crashed one's claim goes");
+        assert!(!unparseable.exists(), "so does a file naming nothing");
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -524,12 +524,28 @@ const OTHER_SESSION_SWEEP: Duration = Duration::from_secs(10);
 /// process moments later, and what it would have cleared is a row the metadata
 /// TTL takes back anyway.
 fn sweep_other_sessions(sockets: Vec<Option<std::path::PathBuf>>) {
+    within(OTHER_SESSION_SWEEP, move || sweep_sessions(sockets));
+}
+
+/// Run `work` on a thread and wait no longer than `deadline` for it.
+///
+/// Returns as soon as the work is done, or when the deadline passes, whichever
+/// comes first; the thread is left to die with the process. A panic in `work`
+/// drops the sender and returns immediately, so a bug in there costs the wait
+/// rather than being hidden by it.
+///
+/// Split out to be tested, which matters more than its four lines suggest. On
+/// Windows this is the ONLY bound on the sweep — a named pipe opened as a
+/// `File` has no timeout to set, so nothing under it can time out on its own —
+/// and CI has no herdr to demonstrate that against. Taking a closure lets the
+/// mechanism be pinned on every platform without one.
+fn within(deadline: Duration, work: impl FnOnce() + Send + 'static) {
     let (done, wait) = std::sync::mpsc::channel();
     thread::spawn(move || {
-        sweep_sessions(sockets);
+        work();
         let _ = done.send(());
     });
-    let _ = wait.recv_timeout(OTHER_SESSION_SWEEP);
+    let _ = wait.recv_timeout(deadline);
 }
 
 /// Everything one session could be carrying from us, as the set to clear.
@@ -1603,6 +1619,54 @@ mod tests {
             .map(|(_, claim)| claim.pid)
             .collect();
         assert_eq!(stopped, vec![4242, 4343]);
+    }
+
+    #[test]
+    fn a_deadline_returns_from_work_that_never_does() {
+        // The one bound the Windows sweep has. A pipe opened as a `File` has no
+        // timeout to set, so if this wait did not come back, `--disable` would
+        // not either — a command the user is watching, hung on a session that
+        // is nothing to do with them. Runs on every platform, which is the
+        // point: CI has no herdr to wedge, and this needs none.
+        let started = std::time::Instant::now();
+        within(Duration::from_millis(50), || {
+            thread::sleep(Duration::from_secs(3600))
+        });
+        assert!(
+            started.elapsed() < Duration::from_secs(30),
+            "waited {:?}",
+            started.elapsed(),
+        );
+    }
+
+    #[test]
+    fn work_that_finishes_does_not_serve_out_the_deadline() {
+        // The other half, and the one a too-eager fix would break: the deadline
+        // is a ceiling, not a delay. Every ordinary `--disable` goes through
+        // here, so waiting it out would add ten seconds to the common case.
+        let started = std::time::Instant::now();
+        within(Duration::from_secs(3600), || {});
+        assert!(
+            started.elapsed() < Duration::from_secs(30),
+            "waited {:?}",
+            started.elapsed(),
+        );
+    }
+
+    #[test]
+    fn a_session_that_is_not_there_costs_nothing_to_sweep() {
+        // A recorded claim outlives the session that wrote it, so most sweeps
+        // dial something that has gone. That has to fail immediately rather
+        // than eat the deadline — on unix the connection is refused, on Windows
+        // the pipe is simply not there to open, and this pins both.
+        let dir = scratch("unreachable");
+        let started = std::time::Instant::now();
+        sweep_sessions(vec![Some(dir.join("herdr.sock")), None]);
+        assert!(
+            started.elapsed() < Duration::from_secs(30),
+            "waited {:?}",
+            started.elapsed(),
+        );
     }
 
     #[test]

--- a/src/disk.rs
+++ b/src/disk.rs
@@ -368,7 +368,18 @@ mod tests {
         let root = if cfg!(windows) { "C:" } else { "/" };
         let readings = read(&[root.to_string(), root.to_string()]);
         assert_eq!(readings.len(), 2);
-        assert_eq!(readings[0], readings[1]);
+        // The NAME is what the order is about, and the only field of a live
+        // reading that holds still. Comparing whole readings made this test
+        // flaky: they are two `statvfs` calls a moment apart, and anything
+        // writing to the disk in between — which on a build machine is
+        // everything — moves `free_mb` a few kilobytes and fails an exact float
+        // comparison. Seen once in roughly a hundred local runs; CI writes far
+        // more than this box does.
+        assert_eq!(readings[0].name, readings[1].name);
+        assert_eq!(readings[0].name, root);
+        // Same filesystem, so its size cannot have changed between the two
+        // calls — unlike how much of it is free.
+        assert_eq!(readings[0].total_mb, readings[1].total_mb);
     }
 
     #[test]

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -387,6 +387,42 @@ pub fn socket_path() -> crate::Result<PathBuf> {
     ))
 }
 
+/// A short, filename-safe name for the herdr session this process talks to.
+///
+/// Each herdr session runs its own server on its own socket — the default
+/// session on `<config_home>/herdr/herdr.sock`, `herdr --session <name>` on
+/// `<config_home>/herdr/sessions/<name>/herdr.sock` — and every plugin process a
+/// session spawns inherits that path in `HERDR_SOCKET_PATH`. herdr's plugin state
+/// dir, by contrast, is one per user and per plugin: `HERDR_PLUGIN_STATE_DIR` is
+/// the same string in every session. So the socket path is the only thing that
+/// names the session from inside a plugin, and anything that must be one *per
+/// session* has to carry this in its file name — see [`crate::config::pid_file`].
+///
+/// A hash rather than the path itself because a file name may not hold a path:
+/// it has separators in it, is longer than some filesystems allow a name to be,
+/// and spells differently on Windows.
+pub fn session_key() -> String {
+    session_key_of(&socket_path().unwrap_or_default().to_string_lossy())
+}
+
+/// [`session_key`] for an explicit socket path.
+///
+/// Hand-rolled FNV-1a rather than `DefaultHasher`, whose output std does not
+/// promise to keep stable between Rust releases. The key has to mean the same
+/// thing to two processes that may have been built by different compilers — a
+/// daemon and the `--restore` that checks up on it — and a key that quietly
+/// changed under a rebuild would let a second updater start alongside the first.
+fn session_key_of(socket_path: &str) -> String {
+    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = OFFSET_BASIS;
+    for byte in socket_path.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    format!("{hash:016x}")
+}
+
 /// The herdr CLI binary (`HERDR_BIN_PATH`, else `herdr`) for the fallback path.
 ///
 /// Deliberately retained but not yet wired: every method currently goes over the
@@ -551,6 +587,47 @@ mod tests {
             socket_path_from(None, config_home),
             PathBuf::from("/home/u/.config/herdr/herdr.sock"),
         );
+    }
+
+    // ---- naming the session -------------------------------------------------
+
+    #[test]
+    fn each_session_socket_gets_its_own_key() {
+        // What the fix turns on: the default session and a named one must not
+        // share a key, or they go back to sharing one updater — and one updater
+        // can only push over the one socket it connected to.
+        let default = session_key_of("/home/u/.config/herdr/herdr.sock");
+        let named = session_key_of("/home/u/.config/herdr/sessions/second/herdr.sock");
+        assert_ne!(default, named);
+        // Same socket, same key: this is what lets `--restore` find the daemon
+        // it started last time instead of starting another one beside it.
+        assert_eq!(default, session_key_of("/home/u/.config/herdr/herdr.sock"));
+    }
+
+    #[test]
+    fn the_session_key_is_a_fixed_width_name_a_filesystem_accepts() {
+        // It becomes part of a file name, so anything a path can hold and a name
+        // cannot — a separator above all — would put the pid file somewhere
+        // nobody looks for it.
+        let key = session_key_of(r"C:\Users\u\AppData\Roaming\herdr\herdr.sock");
+        assert_eq!(key.len(), 16, "got: {key}");
+        assert!(key.chars().all(|c| c.is_ascii_hexdigit()), "got: {key}");
+    }
+
+    #[test]
+    fn the_session_key_is_the_same_one_every_build_computes() {
+        // Pinned to a literal on purpose. Two processes have to agree on this —
+        // a daemon and the `--restore` checking up on it — and they may have
+        // been built by different compilers, so a hash that drifted with the
+        // toolchain would quietly let a second updater start alongside the
+        // first. FNV-1a over the path bytes, exactly this.
+        assert_eq!(
+            session_key_of("/home/u/.config/herdr/herdr.sock"),
+            "42c3c9646ad866b0",
+        );
+        // The empty path is the socket we could not resolve — still a key, and
+        // still its own, rather than a panic or a name shared with a real one.
+        assert_eq!(session_key_of(""), "cbf29ce484222325");
     }
 
     #[cfg(windows)]

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -68,8 +68,36 @@ fn open_stream(path: &Path) -> io::Result<Stream> {
 /// No read/write timeouts: a pipe opened as `File` has no such knobs. That is
 /// the one thing unix gets for free here, so the daemon carries a watchdog
 /// instead — see [`crate::daemon::run_daemon`].
+///
+/// Retries on `ERROR_PIPE_BUSY`, which is a "not this instant" and not a "not
+/// here". herdr's listener keeps exactly ONE free pipe instance and creates the
+/// next only once `accept` has returned, so any connection that lands in that
+/// window is refused outright — herdr's own client rides it out with
+/// `WaitNamedPipeW(FOREVER)`, and a plain `File::open` does not. Treating it as
+/// a dead session is what makes it matter here: `--disable` sweeps sessions that
+/// are busy serving their own UI, and giving up on one leaves its pseudo-agent
+/// rows behind, which carry no TTL to clear them.
 #[cfg(windows)]
 fn open_stream(path: &Path) -> io::Result<Stream> {
+    /// Windows' `ERROR_PIPE_BUSY`: every instance is spoken for, try again.
+    const PIPE_BUSY: i32 = 231;
+    /// Total wait is `TRIES * BUSY_PAUSE`, comfortably inside the sweep's own
+    /// deadline and imperceptible on the connections that never see a retry.
+    const TRIES: u32 = 20;
+    const BUSY_PAUSE: std::time::Duration = std::time::Duration::from_millis(25);
+
+    for _ in 0..TRIES {
+        match open_pipe_once(path) {
+            Err(err) if err.raw_os_error() == Some(PIPE_BUSY) => std::thread::sleep(BUSY_PAUSE),
+            settled => return settled,
+        }
+    }
+    open_pipe_once(path)
+}
+
+/// One attempt at the pipe — see [`open_stream`] for why there may be several.
+#[cfg(windows)]
+fn open_pipe_once(path: &Path) -> io::Result<Stream> {
     use std::os::windows::fs::OpenOptionsExt;
     use windows_sys::Win32::Storage::FileSystem::SECURITY_IDENTIFICATION;
 

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -131,6 +131,15 @@ pub fn connect() -> crate::Result<Herdr> {
     Herdr::open(socket_path()?)
 }
 
+/// Connect to a named socket rather than this process's own.
+///
+/// One caller: `--disable`, clearing the statuses of a session whose updater it
+/// just stopped. Every other path wants [`connect`] — talking to a session other
+/// than your own is the exception, and one that has to name the socket it means.
+pub fn connect_to(path: PathBuf) -> crate::Result<Herdr> {
+    Herdr::open(path)
+}
+
 impl Herdr {
     /// Connect to `path` and wire up the read/write halves.
     fn open(path: PathBuf) -> crate::Result<Herdr> {
@@ -387,7 +396,17 @@ pub fn socket_path() -> crate::Result<PathBuf> {
     ))
 }
 
-/// A short, filename-safe name for the herdr session this process talks to.
+/// The resolved socket path, as the string [`session_key_of`] is taken over.
+///
+/// The one input that names this session, handed on as a path rather than as a
+/// key so that the chain — socket to key to file name — stays reachable from a
+/// single test instead of each half being pinned against the other half's own
+/// arithmetic. Its only caller is [`crate::config::pid_file`].
+pub fn socket_path_string() -> String {
+    socket_path().unwrap_or_default().to_string_lossy().into()
+}
+
+/// A short, filename-safe name for the herdr session reached over `socket_path`.
 ///
 /// Each herdr session runs its own server on its own socket — the default
 /// session on `<config_home>/herdr/herdr.sock`, `herdr --session <name>` on
@@ -401,18 +420,13 @@ pub fn socket_path() -> crate::Result<PathBuf> {
 /// A hash rather than the path itself because a file name may not hold a path:
 /// it has separators in it, is longer than some filesystems allow a name to be,
 /// and spells differently on Windows.
-pub fn session_key() -> String {
-    session_key_of(&socket_path().unwrap_or_default().to_string_lossy())
-}
-
-/// [`session_key`] for an explicit socket path.
 ///
 /// Hand-rolled FNV-1a rather than `DefaultHasher`, whose output std does not
 /// promise to keep stable between Rust releases. The key has to mean the same
 /// thing to two processes that may have been built by different compilers — a
 /// daemon and the `--restore` that checks up on it — and a key that quietly
 /// changed under a rebuild would let a second updater start alongside the first.
-fn session_key_of(socket_path: &str) -> String {
+pub(crate) fn session_key_of(socket_path: &str) -> String {
     const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
     const PRIME: u64 = 0x0000_0100_0000_01b3;
     let mut hash = OFFSET_BASIS;

--- a/src/herdr_config.rs
+++ b/src/herdr_config.rs
@@ -104,7 +104,13 @@ fn write_config(path: &Path, original: &str, updated: &str) -> crate::Result<()>
     if !original.is_empty() {
         std::fs::write(backup_path(path), original)?;
     }
-    let temp = path.with_extension("toml.space-usage-tmp");
+    // Pid in the temp name because more than one of us can be here at once:
+    // herdr runs this plugin once per session and they share this one config.
+    // A fixed name has both writing to the same scratch file and one renaming
+    // it out from under the other, which fails the loser's write for no reason
+    // — recoverable today only because the two are computing byte-identical
+    // content, which is a property of the callers rather than of this function.
+    let temp = path.with_extension(format!("toml.space-usage-tmp.{}", std::process::id()));
     std::fs::write(&temp, updated)?;
     std::fs::rename(&temp, path)?;
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,8 @@ mod proc;
 #[path = "proc_windows.rs"]
 mod proc;
 mod render;
+#[cfg(test)]
+mod testutil;
 
 use std::process;
 

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -1,0 +1,23 @@
+//! Helpers shared by the module test suites.
+//!
+//! One home for the fixtures more than one module needs, so a third suite that
+//! wants a scratch directory copies nothing — the two that had their own before
+//! this file existed had already drifted apart in naming.
+
+use std::path::PathBuf;
+
+/// Unique scratch dir under the system tmpdir, keyed by `name` + pid + thread id
+/// so parallel test threads never collide.
+///
+/// Removed and recreated on the way in rather than out: a test that fails leaves
+/// its fixture behind to look at, and the next run still starts clean.
+pub fn scratch(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "space-usage-test-{name}-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id(),
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    dir
+}

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -9,6 +9,12 @@ use std::path::PathBuf;
 /// Unique scratch dir under the system tmpdir, keyed by `name` + pid + thread id
 /// so parallel test threads never collide.
 ///
+/// `name` must be unique across the whole crate, not just within one suite. The
+/// thread id separates the suites only while they run on different threads, and
+/// `--test-threads=1` — which CI or a bisect may well use — puts every test on
+/// one. Two suites that picked the same name would then wipe each other's
+/// fixture mid-run, which reads as a flake rather than as the collision it is.
+///
 /// Removed and recreated on the way in rather than out: a test that fails leaves
 /// its fixture behind to look at, and the next run still starts clean.
 pub fn scratch(name: &str) -> PathBuf {


### PR DESCRIPTION
Fixes #5.

## The report, validated

Confirmed end-to-end against herdr 0.8.0, not just by reading the code:

- `HERDR_PLUGIN_STATE_DIR` is one dir per **user and plugin** (`~/.local/state/herdr/plugins/ez-corp.space-usage`) — byte-identical in every session.
- `HERDR_SOCKET_PATH` **is** injected into plugin hook and action processes, and **is** per session (`~/.config/herdr/sessions/<name>/herdr.sock`). A `--once` report invoked inside a second session listed only that session's workspaces, so plugin processes really do talk to their own session.
- With a second session running, its `[[startup]]` and `workspace.focused` hooks ran `--restore` and both exited 0 in ~1 ms — the no-op the reporter described. Its workspace carried no `usage` token while the default session's did.

The reporter's diagnosis was right in every link, including the proposed shape of the fix.

## The fix

The pid file is now keyed by session — `<state_dir>/updater-<session>.pid`, where the key is an FNV-1a hash of the resolved `HERDR_SOCKET_PATH`. That path is the only thing naming the session from inside a plugin, and the daemon inherits it from the hook that spawned it. Hand-rolled rather than `DefaultHasher`, whose output std does not promise to keep stable across Rust releases: a key that drifted under a rebuild would let a second updater start beside the first.

What stays shared is what herdr already keeps once per user:

| | Scope | Why |
|---|---|---|
| updater + pid file | per session | it can only push over the socket it connected to |
| `status-enable` / `status-disable` | every session | one state dir per user, and the `$usage` row lives in the one config every session renders |
| `status-toggle` | reads this session | it flips the sidebar in front of you |
| plugin config | every session | one config dir per user |

`--disable` therefore stands down **every** session's updater — including one left holding the un-keyed `updater.pid` across an upgrade — because the row it just removed was the last thing rendering their output. `--enable`, `--restore` and `--toggle` speak only for the session that ran them.

## Verification

Two real herdr sessions, a scratch state dir, and the released 1.11.0 binary against this one:

| scenario | 1.11.0 | this PR |
|---|---|---|
| `--restore` in both sessions | session A `usage`, session B blank | both render |
| six `--restore` runs | — | exactly two daemons, one per session |
| `--disable` from one session | — | both daemons stopped, both sidebars cleared |
| `--restore` after a deliberate disable | — | stays down in both |
| `--enable` in A, `--restore` in B | — | both render again |
| new binary `--disable` vs a 1.11.0 daemon on the legacy pid file | — | stopped |

Unit tests: 246 → 255. The new ones pin the two sessions' claims apart, the `--restore` idempotence within one session, the disable sweep skipping dead and unparseable claims, the pid-file naming and enumeration (legacy file included, `enabled`/`bootstrapped` excluded), and the session key being stable, fixed-width and filename-safe — pinned to a literal, since two processes built by different compilers have to agree on it.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` and `cargo test --all` are clean locally; CI covers macOS and Windows.

Also folds the two copies of the tests' `scratch()` helper into `src/testutil.rs` rather than adding a third.

Ships as 1.11.1.
