### PR TITLE
fix: the macOS CPU fix reaches installed plugins, and its docs say ticks (v1.11.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "space-usage"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "libc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "space-usage"
-version = "1.11.1"
+version = "1.11.2"
 edition = "2021"
 description = "CPU and RAM usage per herdr space, grouped under the branch name."
 license = "MIT"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -14,7 +14,7 @@
 
 id = "ez-corp.space-usage"
 name = "PC RAM & CPU Usage Overlay"
-version = "1.11.1"
+version = "1.11.2"
 # Oldest herdr with every API this plugin calls: `session.snapshot`, the `tokens`
 # metadata API on `pane.report_metadata` / `workspace.report_metadata`, and
 # `pane.process_info` — all 0.7.5. Diffing the two bundled API schemas

--- a/src/proc_macos.rs
+++ b/src/proc_macos.rs
@@ -116,7 +116,7 @@ fn list_pids() -> Vec<u32> {
 /// `proc_pidinfo` returns the number of bytes it wrote, or <= 0 on failure —
 /// EPERM for a process we may not inspect, ESRCH once it exits. A short write
 /// leaves the tail of the struct zeroed, which would read back as a perfectly
-/// plausible "0 ns of CPU, 0 bytes resident" sample, so anything less than a
+/// plausible "0 ticks of CPU, 0 bytes resident" sample, so anything less than a
 /// full-size write is treated as failure rather than as data.
 ///
 /// # Safety
@@ -136,7 +136,7 @@ unsafe fn pid_info<T>(pid: u32, flavor: libc::c_int) -> Option<T> {
     (written == size).then_some(info)
 }
 
-/// Cumulative user+system CPU nanoseconds and RSS bytes for `pid`.
+/// Cumulative user+system CPU ticks (see [`clk_tck`]) and RSS bytes for `pid`.
 fn task_info(pid: u32) -> Option<libc::proc_taskinfo> {
     // SAFETY: `proc_taskinfo` is the POD struct PROC_PIDTASKINFO fills.
     unsafe { pid_info::<libc::proc_taskinfo>(pid, libc::PROC_PIDTASKINFO) }
@@ -148,10 +148,10 @@ fn bsd_info(pid: u32) -> Option<libc::proc_bsdinfo> {
     unsafe { pid_info::<libc::proc_bsdinfo>(pid, libc::PROC_PIDTBSDINFO) }
 }
 
-/// Snapshot the process table once, returning `pid -> {ppid, cpu ns}` for every
-/// live process. Processes whose times are unreadable keep their pid/ppid edge
-/// (the subtree walk needs it) with zero CPU; processes that vanish mid-scan,
-/// or whose parent link we cannot read at all, are skipped.
+/// Snapshot the process table once, returning `pid -> {ppid, cpu ticks}` for
+/// every live process. Processes whose times are unreadable keep their pid/ppid
+/// edge (the subtree walk needs it) with zero CPU; processes that vanish
+/// mid-scan, or whose parent link we cannot read at all, are skipped.
 pub fn scan_proc() -> HashMap<u32, ProcEntry> {
     let mut procs = HashMap::new();
     for pid in list_pids() {
@@ -438,10 +438,7 @@ mod tests {
         let parent = unsafe { libc::getppid() } as u32;
         assert_eq!(me.ppid, parent, "own parent pid mismatch");
         // Our own task is always readable, so its CPU counter is real.
-        assert!(
-            me.jiffies > 0,
-            "own cumulative CPU nanoseconds read as zero"
-        );
+        assert!(me.jiffies > 0, "own cumulative CPU ticks read as zero");
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
Follow-up to #7, which corrected the macOS CPU scale but left two things behind.

## The fix does not ship without a version bump

`herdr-plugin.toml`'s `version` is what an installed plugin compares against to decide whether to update. Leaving it at `1.11.1` merges the fix without delivering it — every Apple Silicon user keeps the under-reported CPU they had. Bumped `Cargo.toml`, `Cargo.lock`, and `herdr-plugin.toml` to `1.11.2`, matching how every prior fix landed (`v1.11.1`, `v1.11.0`, `v1.10.0`, …).

## Four comments still claim nanoseconds

#7 updated the module docs, `ProcEntry`, and `clk_tck`, but `src/proc_macos.rs` still said:

| Line | Said | Now |
|---|---|---|
| `pid_info` short-write note | `"0 ns of CPU, 0 bytes resident"` | `"0 ticks of CPU, …"` |
| `task_info` | "Cumulative user+system CPU **nanoseconds**" | "CPU ticks (see \`clk_tck\`)" |
| `scan_proc` | returning `pid -> {ppid, cpu ns}` | `pid -> {ppid, cpu ticks}` |
| self-sample assertion | "own cumulative CPU **nanoseconds** read as zero" | "own cumulative CPU **ticks** read as zero" |

These describe Mach absolute-time ticks now. This is the same unit confusion that caused the original bug: a reader who trusts them re-derives the wrong scale, which is how `1_000_000_000` got hard-coded in the first place.

No behaviour change beyond the version.

## Tests

- `cargo test --all` — 266 passed (Linux; the macOS-only tests are not compiled here)
- `cargo fmt --all --check`
- `cargo build --release`
- `cargo clippy` could not run locally — this box has `cargo`/`rustc` 1.94.1 but `clippy-driver` 1.92.0, an unrelated toolchain mismatch. Left to CI, which gates clippy on all three platforms.