### PR TITLE
feat: open btop, htop or top from the usage overlay (v1.12.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "space-usage"
-version = "1.11.2"
+version = "1.12.0"
 dependencies = [
  "libc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "space-usage"
-version = "1.11.2"
+version = "1.12.0"
 edition = "2021"
 description = "CPU and RAM usage per herdr space, grouped under the branch name."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ With a Nerd Font installed it detects that and uses icons instead —
 - All-space totals in your terminal's window title:
   `spaces · cpu 39% · ram 8% · bat 74%+ · disk 78% 387G`
 - A live dashboard pane and one-shot report/JSON actions
+- **Opens a system monitor** — `btop`, `htop` or `top`, whichever this machine
+  has — from the action menu, the palette or a key, because the next question
+  after *how much* is *what*. See [System monitor](#system-monitor)
 - A small static Rust binary (~2–5 MB resident) that talks to herdr over its
   unix socket (a named pipe on Windows) — no per-sample subprocess spawns, no
   Node runtime
@@ -136,6 +139,7 @@ Other entrypoints:
 ```sh
 herdr plugin pane open --plugin ez-corp.space-usage --entrypoint dashboard  # live dashboard
 herdr plugin action invoke report --plugin ez-corp.space-usage             # one-shot snapshot
+herdr plugin action invoke monitor --plugin ez-corp.space-usage            # btop / htop / top
 herdr plugin action invoke icons --plugin ez-corp.space-usage              # preview icon tiers
 ./target/release/space-usage --json                                        # machine-readable
 ```
@@ -212,6 +216,7 @@ disk = true                 # likewise — free space, one cell per drive
 disks = "/"                 # which drives; "/, /home" for two, "C:, D:" on Windows
 icons = "auto"              # auto | text | unicode | nerdfont | emoji
 ram_display = "percent"     # or "gb" / "absolute" — see RAM as a figure
+# system_monitor = "btop"   # unset auto-detects btop -> htop -> top
 ```
 
 - **sidebar** (default): renders usage inside each spaces card, under the branch
@@ -402,6 +407,53 @@ no disk of its own to label, so a `disk_label` in its `[ui]` earns an
 disk_label = "free"         # -> free 78% 387G
 disk_label = ""             # -> 78% 387G
 ```
+
+## System monitor
+
+The readout says **how much** of the machine is in use. The next question is
+always **what is using it**, so the plugin opens a monitor:
+
+```sh
+herdr plugin action invoke monitor --plugin ez-corp.space-usage
+```
+
+That is the **Open system monitor** row in herdr's action menu and in the
+palette, so a mouse reaches it. For a key, put this in herdr's `config.toml` —
+`type = "shell"` gets one argv-safe token per word and no shell, which this
+command stays inside:
+
+```toml
+[[keys.command]]
+key = "prefix+m"
+type = "shell"
+command = "herdr plugin pane open --plugin ez-corp.space-usage --entrypoint monitor --placement overlay --focus"
+```
+
+It opens as a zoomed overlay and closes when you quit the monitor — `q` in btop
+and htop, `q` in top. The plugin `exec`s the monitor rather than wrapping it, so
+nothing of ours sits between it and the terminal: resize, `Ctrl-C` and its own
+keys all behave as they would in any pane.
+
+**What it runs.** The first of `btop`, `htop`, `top` on `PATH` — preference
+order, ending on the one every unix already has, so this needs no setup. Name a
+different one in the plugin's `config.toml`:
+
+```toml
+system_monitor = "htop -t"      # split into argv, so flags work
+system_monitor = "btop"
+```
+
+A named command is run as given, even if it is not installed: the error then
+says what you typed rather than quietly starting something else. With nothing
+named and nothing found, the message lists what it looked for and names this key
+— on Windows the list is `btop`, `htop` only, since `top` is not a program there
+and Task Manager is not something to run in a pane.
+
+**The readout itself is not clickable, and cannot be.** herdr exposes no click
+hook for its own chrome — not the tab bar, not the sidebar, not a token row — so
+no plugin can attach one. A local herdr patch used to do it from inside the
+binary; herdr 0.9.0 deleted the file that patch lived in. An action and a key are
+what a plugin can offer, and they reach the same overlay.
 
 ## Icons and labels
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -3,9 +3,10 @@
 # Shows CPU and RAM usage per space (workspace), grouped under each space's
 # git branch name. The sidebar row is the main surface — herdr draws it from a
 # `$usage` token row this plugin adds to herdr's config on first run, since no
-# plugin API can contribute one. Two more surfaces come along with it:
+# plugin API can contribute one. Three more surfaces come along with it:
 #   - a live terminal pane  ("Space usage" overlay)
 #   - a one-shot action     ("Space usage report")
+#   - the system monitor    ("Open system monitor" -> btop / htop / top)
 #
 # Install:     herdr plugin install ezcorp-org/herdr-pc-ram-and-cpu-usage-overlay
 # Local dev:   herdr plugin link /path/to/herdr-pc-ram-and-cpu-usage-overlay   (references the dir in place)
@@ -14,7 +15,7 @@
 
 id = "ez-corp.space-usage"
 name = "PC RAM & CPU Usage Overlay"
-version = "1.11.2"
+version = "1.12.0"
 # Oldest herdr with every API this plugin calls: `session.snapshot`, the `tokens`
 # metadata API on `pane.report_metadata` / `workspace.report_metadata`, and
 # `pane.process_info` — all 0.7.5. Diffing the two bundled API schemas
@@ -83,12 +84,52 @@ title = "Space usage"
 placement = "overlay"
 command = ["./target/release/space-usage", "--interval", "2"]
 
+# The system monitor, full-screen. The readout says how MUCH of the machine is
+# in use; this says WHAT is using it, which is the next question every time.
+#
+# `--monitor` resolves the command (`system_monitor` from the plugin config, else
+# the first of btop / htop / top on PATH) and then `exec`s it, so the process
+# herdr started IS the monitor: resize, Ctrl-C and btop's own `q` reach it
+# directly, and the overlay closes when it quits.
+[[panes]]
+id = "monitor"
+title = "System monitor"
+placement = "overlay"
+command = ["./target/release/space-usage", "--monitor"]
+
 # One-shot snapshot printed to stdout / plugin log.
 [[actions]]
 id = "report"
 title = "Space usage report"
 contexts = ["workspace"]
 command = ["./target/release/space-usage", "--once"]
+
+# What a mouse can actually reach. herdr lists ACTIONS in its menus and in the
+# palette; a [[panes]] entry on its own is reachable only from the CLI, so the
+# pane above needs this row to be clickable at all. herdr offers no hook for a
+# click on the usage readout itself — not the tab bar, not the sidebar, not a
+# token row — so this and a keybinding are the two ways in. The README has the
+# `[[keys.command]]` snippet for the second.
+#
+# The plugin id is repeated here because `pane open` names the plugin by id and
+# TOML cannot reference the `id` key above. Change one, change both.
+[[actions]]
+id = "monitor"
+title = "Open system monitor"
+contexts = ["workspace", "tab", "pane", "global"]
+command = [
+  "herdr",
+  "plugin",
+  "pane",
+  "open",
+  "--plugin",
+  "ez-corp.space-usage",
+  "--entrypoint",
+  "monitor",
+  "--placement",
+  "overlay",
+  "--focus",
+]
 
 # Draws the cpu/ram/battery row in all four icon tiers so the user can pick one
 # by eye. Whether a Nerd Font is installed, and whether the terminal draws emoji

--- a/src/config.rs
+++ b/src/config.rs
@@ -134,6 +134,19 @@ pub struct Config {
     /// reason as [`Config::battery_label`]: herdr has no disk of its own to
     /// label, so `disk_label` is not a key it knows.
     pub disk_label: Option<String>,
+    /// The monitor the "Open system monitor" action runs, whitespace-split into
+    /// argv — so `"htop -t"` is a command with a flag, not a program with a
+    /// space in its name.
+    ///
+    /// `None` (the default) auto-detects; see [`crate::monitor::CANDIDATES`].
+    /// That is the setting to leave alone — the point of the detection is that a
+    /// fresh install opens whatever this machine already has.
+    ///
+    /// EMPTY reads as unset, unlike the labels in this same file. A label can
+    /// deliberately name nothing, leaving a bare figure; a command cannot
+    /// deliberately be nothing, so a blank here is a half-finished edit and
+    /// honouring it literally would break the action with no clue why.
+    pub system_monitor: Option<String>,
 }
 
 impl Default for Config {
@@ -151,6 +164,7 @@ impl Default for Config {
             disk: true,
             disks: default_disks(),
             disk_label: None,
+            system_monitor: None,
         }
     }
 }
@@ -570,9 +584,10 @@ pub(crate) fn herdr_config_path() -> PathBuf {
 /// when they equal the literal `false`, any other value is truthy), `disks` (a
 /// comma-separated drive list), `icons` (a tier name kept verbatim for
 /// [`crate::icons::resolve`]), `ram_display` (`percent` | `gb` | `absolute`,
-/// case-insensitive), and the four label overrides — `cpu_label`, `ram_label`,
-/// `battery_label`, `disk_label` — where an empty value means "name nothing"
-/// rather than unset. Unknown keys are ignored.
+/// case-insensitive), `system_monitor` (a command, empty reading as unset), and
+/// the four label overrides — `cpu_label`, `ram_label`, `battery_label`,
+/// `disk_label` — where an empty value means "name nothing" rather than unset.
+/// Unknown keys are ignored.
 fn parse_config(text: &str) -> Config {
     let mut cfg = Config::default();
     for line in text.split('\n') {
@@ -634,6 +649,10 @@ fn parse_config(text: &str) -> Config {
                     cfg.disks = drives;
                 }
             }
+            // Blank reads as unset, the herdr-side rule rather than the label
+            // rule — see [`Config::system_monitor`]. Stored raw, because the
+            // split into argv belongs to the one place that runs it.
+            "system_monitor" => cfg.system_monitor = non_empty(value),
             // Stored raw: naming the tiers in two places would let the parser
             // and `icons::resolve` disagree about what `Nerd-Font` means.
             "icons" => cfg.icons = value.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@
 //!   --interval N      live watch, refreshing every N seconds (used by the pane)
 //!   --json            emit machine-readable JSON and exit
 //!   --icons           preview every icon tier in this terminal and exit
+//!   --monitor         hand this pane to btop / htop / top (used by the pane)
 //!   --enable          start the sidebar status updater daemon
 //!   --disable         stop the daemon and clear statuses
 //!   --toggle          enable/disable depending on daemon state
@@ -29,6 +30,7 @@ mod herdr;
 mod herdr_config;
 mod icons;
 mod model;
+mod monitor;
 // One `proc` module per platform, selected here so every consumer just says
 // `proc::`. macOS is carved out of the unix arm because it has no `/proc`;
 // the other BSDs stay on the sysfs reader, which is what they had before and
@@ -141,6 +143,13 @@ fn run() -> Result<()> {
             &config::load_herdr_labels().with_overrides(&config),
         );
         return Ok(());
+    }
+
+    // Also ahead of `connect`: the readings come from the monitor's own eyes, not
+    // from herdr, so "what is using my machine" is still answerable when the
+    // server is the thing that has gone wrong.
+    if has_flag(&args, "--monitor") {
+        return monitor::run(config.system_monitor.as_deref());
     }
 
     // Read modes share one socket connection.

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,0 +1,278 @@
+//! The system monitor this plugin opens when you ask the usage readout for more.
+//!
+//! The readout answers *how much*; the monitor answers *what is using it*. herdr
+//! draws no clickable chrome a plugin can hook — not the tab bar, not the sidebar,
+//! not a token row — so the trigger is a plugin action and a keybinding, and this
+//! module is only the part that decides *what to run* and runs it.
+//!
+//! The rule is the one the retired herdr patch
+//! (`dotfiles/herdr/patches/0003-sidebar-system-usage-header.patch`) used when a
+//! click on its sidebar header opened an overlay, down to the spelling of the
+//! config key: an explicit `system_monitor` wins, whitespace-split into argv so
+//! `"htop -t"` works, and otherwise the first of [`CANDIDATES`] on `PATH`. That
+//! patch no longer applies to herdr 0.9.0 — the file it lived in was deleted —
+//! but the rule is what carried the value, and it ports in twenty lines.
+//!
+//! Split the way every other module here is: [`resolve_with`] and [`found_in`]
+//! are pure and tested on every target, and only the two lines that hand the
+//! process over to the monitor touch the host.
+
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::Command;
+
+/// Monitors tried in order when the user has named none.
+///
+/// Order is preference, not availability: `btop` reads best, `htop` is the one
+/// most machines already have, and `top` is the floor — there on every unix
+/// whether anyone installed anything or not, which is what makes the feature
+/// work with no setup.
+#[cfg(not(windows))]
+pub(crate) const CANDIDATES: [&str; 3] = ["btop", "htop", "top"];
+
+/// Windows has no monitor in the box to end the list with — `top` is not a
+/// program there and Task Manager is a GUI, not something to run in a pane — so
+/// the ladder is the two cross-platform TUIs and an honest error below them.
+#[cfg(windows)]
+pub(crate) const CANDIDATES: [&str; 2] = ["btop", "htop"];
+
+/// Resolve the monitor and hand this process over to it.
+///
+/// Never returns on success: on unix the monitor *replaces* this process, and
+/// elsewhere we exit with its status. Either way nothing of ours is left between
+/// herdr and the monitor.
+pub fn run(configured: Option<&str>) -> crate::Result<()> {
+    exec(&resolve(configured)?)
+}
+
+/// The argv to run, from the config value (or its absence).
+fn resolve(configured: Option<&str>) -> crate::Result<Vec<String>> {
+    resolve_with(configured, program_on_path)
+}
+
+/// [`resolve`] against an injected `PATH` lookup.
+///
+/// The seam exists so the decision can be tested without touching the real
+/// `PATH`: a test that set the environment would be testing what the rest of the
+/// suite happens to have installed, and would race every other test thread.
+///
+/// A configured command is returned **unchecked**. The user named it; if it is
+/// not there, `exec` says so with the name they typed, which is a better answer
+/// than silently running something else.
+fn resolve_with(
+    configured: Option<&str>,
+    on_path: impl Fn(&str) -> bool,
+) -> crate::Result<Vec<String>> {
+    let named: Vec<String> = configured
+        .unwrap_or_default()
+        .split_whitespace()
+        .map(str::to_string)
+        .collect();
+    if !named.is_empty() {
+        return Ok(named);
+    }
+    CANDIDATES
+        .iter()
+        .find(|candidate| on_path(candidate))
+        .map(|candidate| vec![candidate.to_string()])
+        .ok_or_else(|| {
+            // Name both the programs looked for and the key that overrides them:
+            // a bare `btop: command not found` tells nobody that a setting could
+            // have pointed this somewhere else.
+            format!(
+                "no system monitor installed — looked for {} on PATH. \
+                 Install one, or name yours with `system_monitor = \"...\"` in \
+                 the plugin's config.toml.",
+                CANDIDATES.join(", "),
+            )
+            .into()
+        })
+}
+
+/// unix: replace this process with the monitor.
+///
+/// `exec` rather than spawn-and-wait so there is no parent of ours holding the
+/// pane's terminal. Resize, `Ctrl-C` and the monitor's own `q` then reach it
+/// exactly as they would in any other pane, and herdr closes the overlay when it
+/// exits, because the process that exits *is* the one herdr started.
+#[cfg(unix)]
+fn exec(argv: &[String]) -> crate::Result<()> {
+    use std::os::unix::process::CommandExt;
+    // Only ever returns on failure, so reaching the next line means it failed.
+    let err = Command::new(&argv[0]).args(&argv[1..]).exec();
+    Err(start_failed(argv, err))
+}
+
+/// Everywhere else (Windows, and anything without `exec`): run it as a child and
+/// leave with its status, so the pane still closes when the monitor does.
+#[cfg(not(unix))]
+fn exec(argv: &[String]) -> crate::Result<()> {
+    let status = Command::new(&argv[0])
+        .args(&argv[1..])
+        .status()
+        .map_err(|err| start_failed(argv, err))?;
+    std::process::exit(status.code().unwrap_or(1));
+}
+
+/// The error for a monitor that would not start, naming the whole command as the
+/// user would have to type it to reproduce.
+fn start_failed(argv: &[String], err: std::io::Error) -> Box<dyn std::error::Error> {
+    format!("cannot start `{}`: {err}", argv.join(" ")).into()
+}
+
+/// Whether `program` is on this machine's `PATH`.
+fn program_on_path(program: &str) -> bool {
+    match std::env::var_os("PATH") {
+        Some(paths) => found_in(&paths, program),
+        None => false,
+    }
+}
+
+/// Whether `program` sits in any directory of a `PATH`-shaped value.
+///
+/// An entry we cannot read simply does not match, so a `PATH` carrying a stale
+/// directory still finds a monitor in the next one.
+fn found_in(paths: &OsStr, program: &str) -> bool {
+    std::env::split_paths(paths).any(|dir| is_program(&dir.join(program)))
+}
+
+/// unix: a program is a file sitting at that path.
+///
+/// Not a permission check. A file on `PATH` that is not executable is a broken
+/// install, and `exec` reports it far more clearly than a silent fall-through to
+/// the next candidate would.
+#[cfg(not(windows))]
+fn is_program(path: &Path) -> bool {
+    path.is_file()
+}
+
+/// Windows: a `PATH` entry holds `btop.exe`, not `btop`, so each executable
+/// suffix is tried as well as the bare name.
+///
+/// `with_extension` is safe for exactly the names that reach here — the
+/// [`CANDIDATES`] — because none of them contains a dot. A configured command
+/// never comes through this function at all.
+#[cfg(windows)]
+fn is_program(path: &Path) -> bool {
+    if path.is_file() {
+        return true;
+    }
+    // The value Windows itself falls back to when PATHEXT is unset.
+    let suffixes = crate::config::non_empty_env("PATHEXT")
+        .unwrap_or_else(|| ".COM;.EXE;.BAT;.CMD".to_string());
+    suffixes
+        .split(';')
+        .filter_map(|suffix| suffix.trim().strip_prefix('.'))
+        .any(|suffix| path.with_extension(suffix).is_file())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testutil::scratch;
+
+    /// A `PATH` value from directories, in the platform's own syntax.
+    fn path_of(dirs: &[&Path]) -> std::ffi::OsString {
+        std::env::join_paths(dirs).expect("joinable paths")
+    }
+
+    // ---- what to run ---------------------------------------------------------
+
+    #[test]
+    fn a_configured_monitor_wins_over_anything_installed() {
+        // Explicit beats detected even when the detected one is right there:
+        // naming a monitor is how you get the one you want, not a hint.
+        let argv = resolve_with(Some("htop -t"), |_| true).expect("configured");
+        assert_eq!(argv, vec!["htop".to_string(), "-t".to_string()]);
+    }
+
+    #[test]
+    fn a_configured_monitor_is_run_even_when_it_is_not_installed() {
+        // The user typed it, so the failure they get names it. Falling back to a
+        // different program would hide the typo.
+        let argv = resolve_with(Some("mymon"), |_| false).expect("configured");
+        assert_eq!(argv, vec!["mymon".to_string()]);
+    }
+
+    #[test]
+    fn a_blank_setting_reads_as_unset_rather_than_as_a_command() {
+        // `system_monitor = ""` and a whitespace-only value are the half-finished
+        // edit, not an instruction to run nothing.
+        for blank in ["", "   ", "\t"] {
+            let argv = resolve_with(Some(blank), |p| p == CANDIDATES[0]).expect("detected");
+            assert_eq!(argv, vec![CANDIDATES[0].to_string()], "{blank:?}");
+        }
+    }
+
+    #[test]
+    fn detection_takes_the_first_candidate_present() {
+        // The ladder is a preference order, so the last candidate is only reached
+        // when nothing above it is installed.
+        let last = *CANDIDATES.last().expect("a candidate");
+        assert_eq!(
+            resolve_with(None, |_| true).expect("detected"),
+            vec![CANDIDATES[0].to_string()],
+        );
+        assert_eq!(
+            resolve_with(None, |p| p == last).expect("detected"),
+            vec![last.to_string()],
+        );
+    }
+
+    #[test]
+    fn nothing_installed_is_an_error_that_names_the_way_out() {
+        // Patch 0003 fell back to a bare `btop` here, because its caller drew the
+        // failure. This one is the message the user reads, so it has to carry
+        // both what was looked for and the key that overrides it.
+        let err = resolve_with(None, |_| false)
+            .expect_err("no monitor")
+            .to_string();
+        for candidate in CANDIDATES {
+            assert!(err.contains(candidate), "{candidate} missing from: {err}");
+        }
+        assert!(err.contains("system_monitor"), "no way out in: {err}");
+    }
+
+    // ---- finding it on PATH --------------------------------------------------
+
+    #[test]
+    fn a_program_is_found_in_a_path_entry_that_holds_it() {
+        let dir = scratch("monitor-path");
+        std::fs::write(dir.join("mymon"), "").expect("write");
+        assert!(found_in(&path_of(&[&dir]), "mymon"));
+        assert!(!found_in(&path_of(&[&dir]), "othermon"));
+    }
+
+    #[test]
+    fn a_path_entry_that_is_not_there_is_skipped_rather_than_fatal() {
+        // A stale directory on PATH is ordinary, and must not stop the search
+        // before the entry that does hold the monitor.
+        let dir = scratch("monitor-path-stale");
+        std::fs::write(dir.join("mymon"), "").expect("write");
+        let gone = dir.join("no-such-dir");
+        assert!(found_in(&path_of(&[&gone, &dir]), "mymon"));
+    }
+
+    #[test]
+    fn a_directory_of_that_name_is_not_a_program() {
+        let dir = scratch("monitor-path-dir");
+        std::fs::create_dir(dir.join("mymon")).expect("mkdir");
+        assert!(!found_in(&path_of(&[&dir]), "mymon"));
+    }
+
+    #[test]
+    fn an_empty_path_finds_nothing() {
+        assert!(!found_in(OsStr::new(""), CANDIDATES[0]));
+    }
+
+    /// The one branch that exists only on Windows: the name on `PATH` carries an
+    /// executable suffix the candidate list does not.
+    #[test]
+    #[cfg(windows)]
+    fn a_windows_executable_is_found_by_its_bare_name() {
+        let dir = scratch("monitor-path-pathext");
+        std::fs::write(dir.join("mymon.exe"), "").expect("write");
+        assert!(found_in(&path_of(&[&dir]), "mymon"));
+        assert!(!found_in(&path_of(&[&dir]), "othermon"));
+    }
+}


### PR DESCRIPTION
## The ask

> Make it so the top resource usage bar is clickable and opens up btop or top or
> htop — whatever the user has installed. We already have this in the code, just
> reuse that.

## What was already there, and why it could not be reused as-is

The launcher lived in a local herdr patch (`dotfiles/herdr/patches/0003-sidebar-system-usage-header.patch`):
an explicit `[ui] system_monitor` wins, whitespace-split into argv so `"htop -t"`
works, else the first of `btop` → `htop` → `top` on `PATH`. Patch 0005 collapsed
the sidebar while the overlay ran.

Those patches were retired on 2026-09-08. herdr 0.9.0 deleted the file patch 0003
lived in (`src/app/system_stats.rs`), so it no longer applies. And **stock herdr
exposes no click hook for any of its own chrome** — not the tab bar, not the
sidebar, not a token row (checked `herdr --default-config`, the 0.9.0 release
notes, `herdr --skill`). No plugin can make the readout itself clickable.

So the **rule** is what got reused — same candidates, same order, same
explicit-override semantics, same spelling of the config key — and the trigger is
what a plugin can actually offer.

## What this adds

- **`src/monitor.rs`** — `resolve` picks the command, `run` hands the process
  over. On unix it `exec`s, so the process herdr started *is* the monitor: resize,
  `Ctrl-C` and its own `q` reach it directly, and the overlay closes when it
  quits. Elsewhere it runs as a child and exits with its status.
- **A `monitor` pane** (overlay) and an **`Open system monitor` action** that
  opens it. The action is the clickable part: herdr lists actions in its menus and
  in the palette. A `[[panes]]` entry on its own is CLI-only.
- **`system_monitor`** in the plugin config. Empty reads as unset — a label can
  deliberately name nothing, a command cannot deliberately be nothing.
- Nothing installed is an **error, not a fallback**: it names what was looked for
  *and* the key that overrides it, because `btop: command not found` says nothing
  about `system_monitor`.
- README section, and `prefix+m` in the dotfiles herdr config (separate repo).

## Verified on a live herdr 0.9.0, installed from this branch

| Check | Result |
|---|---|
| Configured monitor is run | `system_monitor = "echo ..."` → the echo ran, exit 0 |
| Nothing installed | Empty `PATH` → the error names `btop, htop, top` and `system_monitor`, exit 1 |
| Auto-detect in a pane | `--monitor` in a real herdr pane: btop drew |
| Action → overlay | Invoked the action (what a click does): overlay opened, btop drew |
| Clean close | `q` ended btop, the overlay pane disappeared, no stray process |
| Existing surfaces | After the reinstall the `usage` token is still pushed — `{"usage": "cpu 0% · ram 1%"}` |
| Suite | 275 tests pass (9 new), `cargo fmt --check` clean, clippy `-D warnings` clean |

## Notes for review

- The plugin id is repeated inside the action's argv because `pane open` names the
  plugin by id and TOML cannot reference the `id` key above it. Commented as such.
- `resolve_with` takes an injected `on_path` predicate, so no test touches the
  real `PATH` — a test that set the environment would be testing what the runner
  happens to have installed, and would race the other test threads.
- Windows candidates are `btop`, `htop` only: `top` is not a program there and
  Task Manager is not something to run in a pane. `is_program` tries `PATHEXT`
  suffixes, with the one Windows-only branch covered by a `#[cfg(windows)]` test.